### PR TITLE
Implement `semantic-kernel` conformance tests

### DIFF
--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/CRUD/ElasticsearchBatchConformanceTests.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/CRUD/ElasticsearchBatchConformanceTests.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Elasticsearch.ConformanceTests.Support;
+
+using VectorData.ConformanceTests.CRUD;
+
+using Xunit;
+
+namespace Elasticsearch.ConformanceTests.CRUD;
+
+public class ElasticsearchBatchConformanceTests(ElasticsearchSimpleModelFixture fixture)
+    : BatchConformanceTests<string>(fixture), IClassFixture<ElasticsearchSimpleModelFixture>
+{
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/CRUD/ElasticsearchDynamicDataModelConformanceTests.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/CRUD/ElasticsearchDynamicDataModelConformanceTests.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Elasticsearch.ConformanceTests.Support;
+
+using VectorData.ConformanceTests.CRUD;
+
+using Xunit;
+
+namespace Elasticsearch.ConformanceTests.CRUD;
+
+public class ElasticsearchDynamicDataModelConformanceTests(ElasticsearchDynamicDataModelFixture fixture)
+    : DynamicDataModelConformanceTests<string>(fixture), IClassFixture<ElasticsearchDynamicDataModelFixture>
+{
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/CRUD/ElasticsearchNoDataConformanceTests.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/CRUD/ElasticsearchNoDataConformanceTests.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Elasticsearch.ConformanceTests.Support;
+
+using VectorData.ConformanceTests.CRUD;
+using VectorData.ConformanceTests.Support;
+
+using Xunit;
+
+namespace Elasticsearch.ConformanceTests.CRUD;
+
+public class ElasticsearchNoDataConformanceTests(ElasticsearchNoDataConformanceTests.Fixture fixture)
+    : NoDataConformanceTests<string>(fixture), IClassFixture<ElasticsearchNoDataConformanceTests.Fixture>
+{
+    public new class Fixture : NoDataConformanceTests<string>.Fixture
+    {
+        public override TestStore TestStore => ElasticsearchTestStore.Instance;
+    }
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/CRUD/ElasticsearchRecordConformanceTests.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/CRUD/ElasticsearchRecordConformanceTests.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Elasticsearch.ConformanceTests.Support;
+
+using VectorData.ConformanceTests.CRUD;
+
+using Xunit;
+
+namespace Elasticsearch.ConformanceTests.CRUD;
+
+public class ElasticsearchRecordConformanceTests(ElasticsearchSimpleModelFixture fixture)
+    : RecordConformanceTests<string>(fixture), IClassFixture<ElasticsearchSimpleModelFixture>
+{
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Collections/ElasticsearchCollectionConformanceTests.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Collections/ElasticsearchCollectionConformanceTests.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Elasticsearch.ConformanceTests.Support;
+
+using VectorData.ConformanceTests.Collections;
+
+using Xunit;
+
+namespace Elasticsearch.ConformanceTests.Collections;
+
+public class ElasticsearchCollectionConformanceTests(ElasticsearchVectorStoreFixture fixture)
+    : CollectionConformanceTests<string>(fixture), IClassFixture<ElasticsearchVectorStoreFixture>
+{
+    public override string CollectionName => "collection_tests";
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Elastic.SemanticKernel.Connectors.ElasticSearch.ConformanceTests.csproj
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Elastic.SemanticKernel.Connectors.ElasticSearch.ConformanceTests.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Elasticsearch.ConformanceTests</RootNamespace>
+    <NoWarn>$(NoWarn);SKEXP0020</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Elastic.Clients.Elasticsearch" />
+    <PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers" />
+    <PackageReference Include="Testcontainers.Elasticsearch" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Elastic.SemanticKernel.Connectors.Elasticsearch\Elastic.SemanticKernel.Connectors.Elasticsearch.csproj" />
+    <ProjectReference Include="..\test\VectorData.ConformanceTests\VectorData.ConformanceTests.csproj" />
+  </ItemGroup>
+  
+</Project>

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/ElasticsearchDependencyInjectionTests.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/ElasticsearchDependencyInjectionTests.cs
@@ -1,0 +1,102 @@
+using System.Globalization;
+
+using Elastic.Clients.Elasticsearch;
+using Elastic.SemanticKernel.Connectors.Elasticsearch;
+using Elastic.Transport;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using VectorData.ConformanceTests;
+using VectorData.ConformanceTests.Models;
+
+using Xunit;
+
+namespace Elasticsearch.ConformanceTests;
+
+public class ElasticsearchDependencyInjectionTests
+    : DependencyInjectionTests<ElasticsearchVectorStore, ElasticsearchCollection<string, SimpleRecord<string>>, string, SimpleRecord<string>>
+{
+    private const string Host = "localhost";
+    private const int Port = 8080;
+    private const string ApiKey = "fakeKey";
+
+    private static readonly IElasticsearchClientSettings ClientSettings =
+        new ElasticsearchClientSettings(new SingleNodePool(new Uri($"https://{Host}:{Port}")))
+            .Authentication(new ApiKey(ApiKey));
+
+    protected override void PopulateConfiguration(ConfigurationManager configuration, object? serviceKey = null)
+        => configuration.AddInMemoryCollection(
+        [
+            new(CreateConfigKey("Elasticsearch", serviceKey, "Host"), Host),
+            new(CreateConfigKey("Elasticsearch", serviceKey, "Port"), Port.ToString(CultureInfo.InvariantCulture)),
+            new(CreateConfigKey("Elasticsearch", serviceKey, "ApiKey"), ApiKey),
+        ]);
+
+    private static ElasticsearchClientSettings ClientSettingsProvider(IServiceProvider sp, object? serviceKey = null)
+    {
+        var host = sp.GetRequiredService<IConfiguration>().GetRequiredSection(CreateConfigKey("Elasticsearch", serviceKey, "Host")).Value!;
+        var port = int.Parse(sp.GetRequiredService<IConfiguration>().GetRequiredSection(CreateConfigKey("Elasticsearch", serviceKey, "Port")).Value!);
+        var apiKey = sp.GetRequiredService<IConfiguration>().GetRequiredSection(CreateConfigKey("Elasticsearch", serviceKey, "ApiKey")).Value!;
+
+        return new ElasticsearchClientSettings(new SingleNodePool(new Uri($"https://{host}:{port}")))
+            .Authentication(new ApiKey(apiKey));
+    }
+
+    public override IEnumerable<Func<IServiceCollection, object?, string, ServiceLifetime, IServiceCollection>> CollectionDelegates
+    {
+        get
+        {
+            yield return (services, serviceKey, name, lifetime) => serviceKey is null
+                ? services
+                    .AddSingleton<ElasticsearchClient>(sp => new ElasticsearchClient(ClientSettings))
+                    .AddElasticsearchCollection<string, SimpleRecord<string>>(name, lifetime: lifetime)
+                : services
+                    .AddSingleton<ElasticsearchClient>(sp => new ElasticsearchClient(ClientSettings))
+                    .AddKeyedElasticsearchCollection<string, SimpleRecord<string>>(serviceKey, name, lifetime: lifetime);
+
+            yield return (services, serviceKey, name, lifetime) => serviceKey is null
+                ? services.AddElasticsearchCollection<string, SimpleRecord<string>>(
+                    name, ClientSettings, lifetime: lifetime)
+                : services.AddKeyedElasticsearchCollection<string, SimpleRecord<string>>(
+                    serviceKey, name, ClientSettings, lifetime: lifetime);
+
+            yield return (services, serviceKey, name, lifetime) => serviceKey is null
+                ? services.AddElasticsearchCollection<string, SimpleRecord<string>>(
+                    name, sp => new ElasticsearchClient(ClientSettingsProvider(sp)), lifetime: lifetime)
+                : services.AddKeyedElasticsearchCollection<string, SimpleRecord<string>>(
+                    serviceKey, name, sp => new ElasticsearchClient(ClientSettingsProvider(sp, serviceKey)), lifetime: lifetime);
+        }
+    }
+
+    public override IEnumerable<Func<IServiceCollection, object?, ServiceLifetime, IServiceCollection>> StoreDelegates
+    {
+        get
+        {
+            yield return (services, serviceKey, lifetime) => serviceKey is null
+                ? services.AddElasticsearchVectorStore(ClientSettings, lifetime: lifetime)
+                : services.AddKeyedElasticsearchVectorStore(serviceKey, ClientSettings, lifetime: lifetime);
+
+            yield return (services, serviceKey, lifetime) => serviceKey is null
+                ? services
+                    .AddSingleton<ElasticsearchClient>(sp => new ElasticsearchClient(ClientSettings))
+                    .AddElasticsearchVectorStore(lifetime: lifetime)
+                : services
+                    .AddSingleton<ElasticsearchClient>(sp => new ElasticsearchClient(ClientSettings))
+                    .AddKeyedElasticsearchVectorStore(serviceKey, lifetime: lifetime);
+        }
+    }
+
+    [Fact]
+    public void ClientSettingsCantBeNull()
+    {
+        IServiceCollection services = new ServiceCollection();
+
+        Assert.Throws<ArgumentNullException>(() => services.AddElasticsearchVectorStore(clientSettings: null!));
+        Assert.Throws<ArgumentNullException>(() => services.AddKeyedElasticsearchVectorStore(serviceKey: "notNull", clientSettings: null!));
+        Assert.Throws<ArgumentNullException>(() => services.AddElasticsearchCollection<ulong, SimpleRecord<ulong>>(
+            name: "notNull", clientSettings: null!));
+        Assert.Throws<ArgumentNullException>(() => services.AddKeyedElasticsearchCollection<ulong, SimpleRecord<ulong>>(
+            serviceKey: "notNull", name: "notNull", clientSettings: null!));
+    }
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/ElasticsearchEmbeddingGenerationTests.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/ElasticsearchEmbeddingGenerationTests.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Elasticsearch.ConformanceTests.Support;
+
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.VectorData;
+
+using VectorData.ConformanceTests;
+using VectorData.ConformanceTests.Support;
+
+using Xunit;
+
+namespace Elasticsearch.ConformanceTests;
+
+public class ElasticsearchEmbeddingGenerationTests(ElasticsearchEmbeddingGenerationTests.StringVectorFixture stringVectorFixture, ElasticsearchEmbeddingGenerationTests.RomOfFloatVectorFixture romOfFloatVectorFixture)
+    : EmbeddingGenerationTests<Guid>(stringVectorFixture, romOfFloatVectorFixture), IClassFixture<ElasticsearchEmbeddingGenerationTests.StringVectorFixture>, IClassFixture<ElasticsearchEmbeddingGenerationTests.RomOfFloatVectorFixture>
+{
+    public new class StringVectorFixture : EmbeddingGenerationTests<Guid>.StringVectorFixture
+    {
+        public override TestStore TestStore => ElasticsearchTestStore.Instance;
+
+        public override string CollectionName => "embedding_generation_tests";
+
+        public override VectorStore CreateVectorStore(IEmbeddingGenerator? embeddingGenerator)
+            => ElasticsearchTestStore.Instance.GetVectorStore(new() { EmbeddingGenerator = embeddingGenerator });
+
+        public override Func<IServiceCollection, IServiceCollection>[] DependencyInjectionStoreRegistrationDelegates =>
+        [
+            services => services
+                .AddSingleton(ElasticsearchTestStore.Instance.Client)
+                .AddElasticsearchVectorStore()
+        ];
+
+        public override Func<IServiceCollection, IServiceCollection>[] DependencyInjectionCollectionRegistrationDelegates =>
+        [
+            services => services
+                .AddSingleton(ElasticsearchTestStore.Instance.Client)
+                .AddElasticsearchCollection<Guid, RecordWithAttributes>(this.CollectionName)
+        ];
+    }
+
+    public new class RomOfFloatVectorFixture : EmbeddingGenerationTests<Guid>.RomOfFloatVectorFixture
+    {
+        public override TestStore TestStore => ElasticsearchTestStore.Instance;
+
+        public override string CollectionName => "search_only_embedding_generation_tests";
+
+        public override VectorStore CreateVectorStore(IEmbeddingGenerator? embeddingGenerator)
+            => ElasticsearchTestStore.Instance.GetVectorStore(new() { EmbeddingGenerator = embeddingGenerator });
+
+        public override Func<IServiceCollection, IServiceCollection>[] DependencyInjectionStoreRegistrationDelegates =>
+        [
+            services => services
+                .AddSingleton(ElasticsearchTestStore.Instance.Client)
+                .AddElasticsearchVectorStore()
+        ];
+
+        public override Func<IServiceCollection, IServiceCollection>[] DependencyInjectionCollectionRegistrationDelegates =>
+        [
+            services => services
+                .AddSingleton(ElasticsearchTestStore.Instance.Client)
+                .AddElasticsearchCollection<Guid, RecordWithAttributes>(this.CollectionName)
+        ];
+    }
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/ElasticsearchEmbeddingTypeTests.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/ElasticsearchEmbeddingTypeTests.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Elasticsearch.ConformanceTests.Support;
+
+using Microsoft.Extensions.AI;
+
+using VectorData.ConformanceTests;
+using VectorData.ConformanceTests.Support;
+
+using Xunit;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace Elasticsearch.ConformanceTests;
+
+public class ElasticsearchEmbeddingTypeTests(ElasticsearchEmbeddingTypeTests.Fixture fixture)
+    : EmbeddingTypeTests<Guid>(fixture), IClassFixture<ElasticsearchEmbeddingTypeTests.Fixture>
+{
+    public new class Fixture : EmbeddingTypeTests<Guid>.Fixture
+    {
+        public override TestStore TestStore => ElasticsearchTestStore.Instance;
+
+        public override string CollectionName => "embedding_type_tests";
+    }
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Filter/ElasticsearchBasicFilterTests.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Filter/ElasticsearchBasicFilterTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Elasticsearch.ConformanceTests.Support;
+
+using VectorData.ConformanceTests.Filter;
+using VectorData.ConformanceTests.Support;
+
+using Xunit;
+
+namespace Elasticsearch.ConformanceTests.Filter;
+
+public class ElasticsearchBasicFilterTests(ElasticsearchBasicFilterTests.Fixture fixture)
+    : BasicFilterTests<string>(fixture), IClassFixture<ElasticsearchBasicFilterTests.Fixture>
+{
+    public new class Fixture : BasicFilterTests<string>.Fixture
+    {
+        public override TestStore TestStore => ElasticsearchTestStore.Instance;
+
+        public override string CollectionName => "filter_tests";
+    }
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Filter/ElasticsearchBasicQueryTests.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Filter/ElasticsearchBasicQueryTests.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Elasticsearch.ConformanceTests.Support;
+
+using VectorData.ConformanceTests.Filter;
+using VectorData.ConformanceTests.Support;
+
+using Xunit;
+
+namespace Elasticsearch.ConformanceTests.Filter;
+
+public class ElasticsearchBasicQueryTests(ElasticsearchBasicQueryTests.Fixture fixture)
+    : BasicQueryTests<string>(fixture), IClassFixture<ElasticsearchBasicQueryTests.Fixture>
+{
+    public new class Fixture : BasicQueryTests<string>.QueryFixture
+    {
+        public override TestStore TestStore => ElasticsearchTestStore.Instance;
+
+        public override string CollectionName => "query_tests";
+    }
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/HybridSearch/ElasticsearchKeywordVectorizedHybridSearchTests.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/HybridSearch/ElasticsearchKeywordVectorizedHybridSearchTests.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Elasticsearch.ConformanceTests.Support;
+
+using VectorData.ConformanceTests.HybridSearch;
+using VectorData.ConformanceTests.Support;
+
+using Xunit;
+
+namespace Elasticsearch.ConformanceTests.HybridSearch;
+
+public class ElasticsearchKeywordVectorizedHybridSearchTests(
+    ElasticsearchKeywordVectorizedHybridSearchTests.VectorAndStringFixture vectorAndStringFixture,
+    ElasticsearchKeywordVectorizedHybridSearchTests.MultiTextFixture multiTextFixture)
+    : KeywordVectorizedHybridSearchComplianceTests<string>(vectorAndStringFixture, multiTextFixture),
+        IClassFixture<ElasticsearchKeywordVectorizedHybridSearchTests.VectorAndStringFixture>,
+        IClassFixture<ElasticsearchKeywordVectorizedHybridSearchTests.MultiTextFixture>
+{
+    public new class VectorAndStringFixture : KeywordVectorizedHybridSearchComplianceTests<string>.VectorAndStringFixture
+    {
+        public override TestStore TestStore => ElasticsearchTestStore.Instance;
+
+        public override string CollectionName => "keyword_hybrid_search" + GetUniqueCollectionName();
+        protected override string IndexKind => Microsoft.Extensions.VectorData.IndexKind.Hnsw;
+    }
+
+    public new class MultiTextFixture : KeywordVectorizedHybridSearchComplianceTests<string>.MultiTextFixture
+    {
+        public override TestStore TestStore => ElasticsearchTestStore.Instance;
+
+        public override string CollectionName => "keyword_hybrid_search" + GetUniqueCollectionName();
+        protected override string IndexKind => Microsoft.Extensions.VectorData.IndexKind.Hnsw;
+    }
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Support/ElasticsearchDynamicDataModelFixture.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Support/ElasticsearchDynamicDataModelFixture.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using VectorData.ConformanceTests.Support;
+
+namespace Elasticsearch.ConformanceTests.Support;
+
+public class ElasticsearchDynamicDataModelFixture : DynamicDataModelFixture<string>
+{
+    public override TestStore TestStore => ElasticsearchTestStore.Instance;
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Support/ElasticsearchSimpleModelFixture.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Support/ElasticsearchSimpleModelFixture.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using VectorData.ConformanceTests.Support;
+
+namespace Elasticsearch.ConformanceTests.Support;
+
+public class ElasticsearchSimpleModelFixture : SimpleModelFixture<string>
+{
+    public override TestStore TestStore => ElasticsearchTestStore.Instance;
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Support/ElasticsearchTestStore.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Support/ElasticsearchTestStore.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Elastic.Clients.Elasticsearch;
+using Elastic.SemanticKernel.Connectors.Elasticsearch;
+using Elastic.Transport;
+
+using Microsoft.Extensions.VectorData;
+
+using Testcontainers.Elasticsearch;
+
+using VectorData.ConformanceTests.Support;
+
+namespace Elasticsearch.ConformanceTests.Support;
+
+#pragma warning disable CA1001 // Type owns disposable fields but is not disposable
+
+internal sealed class ElasticsearchTestStore : TestStore
+{
+    public static ElasticsearchTestStore Instance { get; } = new();
+
+    private readonly ElasticsearchContainer _container = new ElasticsearchBuilder()
+        .WithImage("elasticsearch:8.18.1")
+        .WithEnvironment("discovery.type", "single-node")
+        .WithEnvironment("xpack.security.enabled", "false")
+        .WithEnvironment("xpack.license.self_generated.type", "trial")
+        .Build();
+
+    private ElasticsearchClient? _client;
+
+    public ElasticsearchClient Client => this._client ?? throw new InvalidOperationException("Not initialized");
+
+    public ElasticsearchVectorStore GetVectorStore(ElasticsearchVectorStoreOptions options)
+        => new(this.Client,
+            ownsClient: false, // The client is shared, it's not owned by the vector store.
+            new()
+            {
+                EmbeddingGenerator = options.EmbeddingGenerator
+            });
+
+    private ElasticsearchTestStore()
+    {
+    }
+
+    public override bool VectorsComparable => true;
+
+    protected override async Task StartAsync()
+    {
+        await this._container.StartAsync();
+
+        var host = this._container.Hostname;
+        var port = this._container.GetMappedPublicPort(ElasticsearchBuilder.ElasticsearchHttpsPort);
+
+        var settings = new ElasticsearchClientSettings(new SingleNodePool(new Uri($"http://{host}:{port}")))
+            .Authentication(new BasicAuthentication(ElasticsearchBuilder.DefaultUsername, ElasticsearchBuilder.DefaultPassword))
+            .ServerCertificateValidationCallback(((_, _, _, _) => true))
+            .EnableDebugMode();
+        this._client = new ElasticsearchClient(settings);
+
+        // The client is shared, it's not owned by the vector store.
+        this.DefaultVectorStore = new ElasticsearchVectorStore(this._client, ownsClient: false, new());
+    }
+
+    protected override async Task StopAsync()
+    {
+        this._client?.ElasticsearchClientSettings.Dispose();
+        await this._container.StopAsync();
+    }
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Support/ElasticsearchVectorStoreFixture.cs
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/Support/ElasticsearchVectorStoreFixture.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using VectorData.ConformanceTests.Support;
+
+namespace Elasticsearch.ConformanceTests.Support;
+
+public class ElasticsearchVectorStoreFixture : VectorStoreFixture
+{
+    public override TestStore TestStore => ElasticsearchTestStore.Instance;
+}

--- a/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/packages.lock.json
+++ b/Elastic.SemanticKernel.Connectors.Elasticsearch.ConformanceTests/packages.lock.json
@@ -1,0 +1,769 @@
+{
+  "version": 2,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Elastic.Clients.Elasticsearch": {
+        "type": "Direct",
+        "requested": "[8.18.0, )",
+        "resolved": "8.18.0",
+        "contentHash": "3CNnsyG4Md9Gj7FEiAc+OPz0MuejFADpomBfZ5Y2ZLsW5V3x9noF1XQ6+beYGgqyUA6Vh/Uzgesh57An0iSoGA==",
+        "dependencies": {
+          "Elastic.Transport": "0.5.9",
+          "Microsoft.NETFramework.ReferenceAssemblies": "1.0.2"
+        }
+      },
+      "Microsoft.Build.CopyOnWrite": {
+        "type": "Direct",
+        "requested": "[1.0.334, )",
+        "resolved": "1.0.334",
+        "contentHash": "Bi/e5guuwmyPL7Kp1G+PbcDvZFKsZxuHmc39IpYHAhWOvV8I/uIHPwAZ++Fa8k/w6pEqPdHCIrxSCelMNmu0dQ=="
+      },
+      "Microsoft.Extensions.VectorData.Abstractions": {
+        "type": "Direct",
+        "requested": "[9.5.0, )",
+        "resolved": "9.5.0",
+        "contentHash": "+hvBYS60Tp9ELEpBVOEa1qBaWgJiEzI9cZdlKf00zJULgI6oPYN/xYps4SaFvyf3O8C+WsDC3Ilsfc147nwVuQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Microsoft.Extensions.AI.Abstractions": "9.5.0",
+          "System.Text.Json": "8.0.5",
+          "System.ValueTuple": "4.6.1"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1"
+        }
+      },
+      "Testcontainers": {
+        "type": "Direct",
+        "requested": "[4.5.0, )",
+        "resolved": "4.5.0",
+        "contentHash": "2xv1dwf3wjbUpEPIpFIrSaHJNDT0helyOTci2u++jvpTurRYtiNacxYWk7rGnEb1sct2EjBtoI6t5wXsOH8yhw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.1",
+          "Docker.DotNet.Enhanced": "3.128.1",
+          "Docker.DotNet.Enhanced.X509": "3.128.1",
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Microsoft.Bcl.HashCode": "1.1.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2024.2.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "Testcontainers.Elasticsearch": {
+        "type": "Direct",
+        "requested": "[4.5.0, )",
+        "resolved": "4.5.0",
+        "contentHash": "XGHdmKtW2g6IHeK5+IrZx/Hk/ehSx7rQu6ZnOPGfD/nylbvFK2XY48b2oUrFtgPODfBNn9IQy0jrXyps20W4qA==",
+        "dependencies": {
+          "Testcontainers": "4.5.0"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "gNu2zhnuwjq5vQlU4S7yK/lfaKZDLmtcu+vTjnhfTlMAUYn+Hmgu8IIX0UCwWepYkk+Szx03DHx1bDnc9Fd+9w==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.13.0"
+        }
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.1",
+        "contentHash": "vZsG2YILhthgRqO+ZVgRff4ZFKKTl0v7kqaVBLCtRvpREhfBP33pcWrdA3PRYgWuFL1RxiUFvjMUHTdBZlJcoA=="
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.128.1",
+        "contentHash": "uzme+90PSNBjgWph3jxboxoL4K3j5ZPHj14WHL7TNkcGxtpP8EFxibNTrXGpEvsmiom0aaIW60ju/JPdNvUSng==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "System.IO.Pipelines": "8.0.0",
+          "System.Net.Http.Json": "8.0.1",
+          "System.Text.Json": "8.0.5"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.128.1",
+        "contentHash": "v2H5XK7HAyDkACpdgodzTcMXIYwjJ9fmwl7mYQ3nVZ/d/XsI1Eh3DrBvCuSNAyNFUL4kz55wFqdzApyRfU01gw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.5.1",
+          "Docker.DotNet.Enhanced": "3.128.1"
+        }
+      },
+      "Elastic.Transport": {
+        "type": "Transitive",
+        "resolved": "0.5.9",
+        "contentHash": "RXoJAeXKaXq67SeLhyDMBPpvlkG940jqJWd5l+rKglMRLJn6X0dkLNlWehpDuouicNdwnYdcuADnqdSOiSvASw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.7.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
+          "System.Text.Json": "8.0.5"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "82rLw487j5jBXEi2r3WvA/cagOhcRREVRtet6izzjDMY+i392W5oNSN2KCtuIvlTpyMONEUD0MIlGAgDdsvQ/w==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.Bcl.HashCode": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "MalY0Y/uM/LjXtHfX/26l2VtN4LDNZ2OE3aumNOHDLsT4fNYy2hiHXI4CXCqKpNUNm7iJ2brrc4J89UdaL56FA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.CSharp": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "pTj+D3uJWyN3My70i2Hqo+OXixq3Os2D1nJ2x92FFo6sk8fYS1m1WLNTs0Dc1uPaViH0YvEEwvzddQ7y4rhXmA=="
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3lE/iLSutpgX1CC0NOW70FJoGARRHbyKmG7dc0klnUZ9Dd9hS6N/POPWhKhMLCEuNN5nXEY5agmlFtH562vqhQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.3",
+        "contentHash": "dL0QGToTxggRLMYY4ZYX5AMwBb+byQBd/5dMiZE07Nv73o6I5Are3C7eQTh7K2+A4ct0PVISSr7TZANbiNb2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "5/cSEVld+px/CuRrbohO/djfg6++eR6zGpy88MgqloXvkj//WXWpFZyu/OpkXPN0u5m+dN/EVwLNYFUxD4h2+A==",
+        "dependencies": {
+          "Microsoft.NETFramework.ReferenceAssemblies.net472": "1.0.2"
+        }
+      },
+      "Microsoft.NETFramework.ReferenceAssemblies.net472": {
+        "type": "Transitive",
+        "resolved": "1.0.2",
+        "contentHash": "ryAuwkvjMC9xYQ0VXsG7ZBo62y5tBmYaCnovOL5IXfnQPQqjvJGRkLMDyUx+dnCb96UVLJv83R6XK+sRnDnaZg=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.13.0",
+        "contentHash": "bt0E0Dx+iqW97o4A59RCmUmz/5NarJ7LRL+jXbSHod72ibL5XdNm1Ke+UO5tFhBG4VwHLcSjqq9BUSblGNWamw==",
+        "dependencies": {
+          "System.Reflection.Metadata": "1.6.0"
+        }
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A==",
+        "dependencies": {
+          "System.Memory": "4.5.4",
+          "System.Threading.Tasks.Extensions": "4.5.2"
+        }
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2024.2.0",
+        "contentHash": "9r+4UF2P51lTztpd+H7SJywk7WgmlWB//Cm2o96c6uGVZU5r58ys2/cD9pCgTk0zCdSkfflWL1WtqQ9I4IVO9Q==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.4.0",
+          "Microsoft.Bcl.AsyncInterfaces": "1.0.0",
+          "System.Formats.Asn1": "8.0.1"
+        }
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "1.5.0",
+        "contentHash": "EXKiDFsChZW0RjrZ4FYHu9aW6+P4MCgEDCklsVseRfhoO0F+dXeMSsMRAlVXIo06kGJ/zv+2w1a2uc2+kxxSaQ=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "c9xLpVz6PL9lp/djOWtk5KPDZq3cSYpmXoJQY524EOtuFl5z9ZtsotpsyrDW40U1DRnQSYvcPKEUV0X//u6gkQ==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Formats.Asn1": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "XqKba7Mm/koKSjKMfW82olQdmfbI5yqeoLV/tidRp7fbh5rmHAQ5raDI/7SU0swTzv+jgqtUGkzmFxuUg0it1A==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "0nlr0reXrRmkZNKifKqh2DgGhQgfkT7Qa3gQxIn/JI7/y3WDiTz67M+Sq3vFhUqcG8O5zVrpqHvIHeGPGUBsEw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.Net.Http.Json": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "F423ZLoJFYg1s6iA+Y7BLflVKjEK5XEA2+Z9CHbxJEUtS3+R5pgnFN499QzriRjYpOu6kS2Crd2YBkOFDHrblg==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Text.Json": "8.0.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "COC1aiAJjCoA5GBF+QKL2uLqEBew4JsCkQmoHKbN3TlOZKa2fKLz5CpiRQKDz0RsAOEGsVKqOD5bomsXq/4STQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "1.5.0"
+        }
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "uWRgViw2yJAUyGxrzDLCc6fkzE2dZIoXxs8V6YjCujKsJuP0pnpYSlbm2/7tKd0SjBnMtwfDQhLenk3bXonVOA==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.6.1",
+        "contentHash": "+RJT4qaekpZ7DDLhf+LTjq+E48jieKiY9ulJ+BoxKmZblIJfIJT8Ufcaa/clQqnYvWs8jugfGSMu8ylS0caG0w=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "elastic.semantickernel.connectors.elasticsearch": {
+        "type": "Project",
+        "dependencies": {
+          "Elastic.Clients.Elasticsearch": "[8.18.0, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[9.0.6, )",
+          "Microsoft.Extensions.VectorData.Abstractions": "[9.5.0, )",
+          "MinVer": "[6.0.0, )",
+          "System.Text.Json": "[9.0.6, )"
+        }
+      },
+      "vectordata.conformancetests": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "[9.6.0, )",
+          "Microsoft.Extensions.Configuration": "[8.0.0, )",
+          "Microsoft.Extensions.DependencyInjection": "[8.0.1, )",
+          "Microsoft.Extensions.VectorData.Abstractions": "[9.5.0, )",
+          "System.Linq.Async": "[6.0.1, )",
+          "System.Memory.Data": "[9.0.6, )",
+          "xunit": "[2.9.3, )"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[9.6.0, )",
+        "resolved": "9.6.0",
+        "contentHash": "xGO7rHg3qK8jRdriAxIrsH4voNemCf8GVmgdcPXI5gpZ6lZWqOEM4ZO8yfYxUmg7+URw2AY1h7Uc/H17g7X1Kw==",
+        "dependencies": {
+          "System.Text.Json": "8.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "0J/9YNXTMWSZP2p2+nvl8p71zpSwokZXZuJW+VjdErkegAnFdO1XlqtA62SJtgVYHdKu3uPxJHcMR/r35HwFBA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "BmANAnR5Xd4Oqw7yQ75xOAYODybZQRzdeNucg7kS5wWKd2PNnMdYtJ2Vciy0QLylRmv42DGl5+AFL9izA6F1Rw==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "0Zn6nR/6g+90MxskZyOOMPQvnPnrrGu6bytPwkV+azDcTtCSuQ1+GJUrg8Klmnrjk1i6zMpw2lXijl+tw7Q3kA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.6",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "MinVer": {
+        "type": "CentralTransitive",
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "+/SsmiySsXJlvQLCGBqaZKNVt3s/Y/HbAdwtop7Km2CnuZbaScoqkWJEBQ5Cy9ebkn6kCYKrHsXgwrFdTgcb3g=="
+      },
+      "System.Linq.Async": {
+        "type": "CentralTransitive",
+        "requested": "[6.0.1, )",
+        "resolved": "6.0.1",
+        "contentHash": "0YhHcaroWpQ9UCot3Pizah7ryAzQhNvobLMSxeDIGmnXfkQn8u5owvpOH0K6EVB+z9L7u6Cc4W17Br/+jyttEQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "System.Memory.Data": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "+GDe33iytnNIelPNB0dL/zhQCGDy3Tbhkx11LkHY8EtPKx+TZHEeCA2pDs7RFf7nAbNLSNxpx6ynjhTo0s0U9w==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Text.Json": "9.0.6"
+        }
+      },
+      "System.Text.Json": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "h+ZtYTyTnTh5Ju6mHCKb3FPGx4ylJZgm9W7Y2psUnkhQRPMOIxX+TCN0ZgaR/+Yea+93XHWAaMzYTar1/EHIPg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.6",
+          "System.Buffers": "4.5.1",
+          "System.IO.Pipelines": "9.0.6",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "9.0.6",
+          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "xunit.abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      }
+    },
+    "net8.0": {
+      "Elastic.Clients.Elasticsearch": {
+        "type": "Direct",
+        "requested": "[8.18.0, )",
+        "resolved": "8.18.0",
+        "contentHash": "3CNnsyG4Md9Gj7FEiAc+OPz0MuejFADpomBfZ5Y2ZLsW5V3x9noF1XQ6+beYGgqyUA6Vh/Uzgesh57An0iSoGA==",
+        "dependencies": {
+          "Elastic.Transport": "0.5.9"
+        }
+      },
+      "Microsoft.Build.CopyOnWrite": {
+        "type": "Direct",
+        "requested": "[1.0.334, )",
+        "resolved": "1.0.334",
+        "contentHash": "Bi/e5guuwmyPL7Kp1G+PbcDvZFKsZxuHmc39IpYHAhWOvV8I/uIHPwAZ++Fa8k/w6pEqPdHCIrxSCelMNmu0dQ=="
+      },
+      "Microsoft.Extensions.VectorData.Abstractions": {
+        "type": "Direct",
+        "requested": "[9.5.0, )",
+        "resolved": "9.5.0",
+        "contentHash": "+hvBYS60Tp9ELEpBVOEa1qBaWgJiEzI9cZdlKf00zJULgI6oPYN/xYps4SaFvyf3O8C+WsDC3Ilsfc147nwVuQ==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "9.5.0"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1",
+          "Microsoft.TestPlatform.TestHost": "17.14.1"
+        }
+      },
+      "Testcontainers": {
+        "type": "Direct",
+        "requested": "[4.5.0, )",
+        "resolved": "4.5.0",
+        "contentHash": "2xv1dwf3wjbUpEPIpFIrSaHJNDT0helyOTci2u++jvpTurRYtiNacxYWk7rGnEb1sct2EjBtoI6t5wXsOH8yhw==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.128.1",
+          "Docker.DotNet.Enhanced.X509": "3.128.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2024.2.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "Testcontainers.Elasticsearch": {
+        "type": "Direct",
+        "requested": "[4.5.0, )",
+        "resolved": "4.5.0",
+        "contentHash": "XGHdmKtW2g6IHeK5+IrZx/Hk/ehSx7rQu6ZnOPGfD/nylbvFK2XY48b2oUrFtgPODfBNn9IQy0jrXyps20W4qA==",
+        "dependencies": {
+          "Testcontainers": "4.5.0"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.1, )",
+        "resolved": "3.1.1",
+        "contentHash": "gNu2zhnuwjq5vQlU4S7yK/lfaKZDLmtcu+vTjnhfTlMAUYn+Hmgu8IIX0UCwWepYkk+Szx03DHx1bDnc9Fd+9w=="
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.4.0",
+        "contentHash": "SwXsAV3sMvAU/Nn31pbjhWurYSjJ+/giI/0n6tCrYoupEK34iIHCuk3STAd9fx8yudM85KkLSVdn951vTng/vQ=="
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.128.1",
+        "contentHash": "uzme+90PSNBjgWph3jxboxoL4K3j5ZPHj14WHL7TNkcGxtpP8EFxibNTrXGpEvsmiom0aaIW60ju/JPdNvUSng==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.128.1",
+        "contentHash": "v2H5XK7HAyDkACpdgodzTcMXIYwjJ9fmwl7mYQ3nVZ/d/XsI1Eh3DrBvCuSNAyNFUL4kz55wFqdzApyRfU01gw==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.128.1"
+        }
+      },
+      "Elastic.Transport": {
+        "type": "Transitive",
+        "resolved": "0.5.9",
+        "contentHash": "RXoJAeXKaXq67SeLhyDMBPpvlkG940jqJWd5l+rKglMRLJn6X0dkLNlWehpDuouicNdwnYdcuADnqdSOiSvASw=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3lE/iLSutpgX1CC0NOW70FJoGARRHbyKmG7dc0klnUZ9Dd9hS6N/POPWhKhMLCEuNN5nXEY5agmlFtH562vqhQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.3",
+        "contentHash": "dL0QGToTxggRLMYY4ZYX5AMwBb+byQBd/5dMiZE07Nv73o6I5Are3C7eQTh7K2+A4ct0PVISSr7TZANbiNb2yQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ==",
+        "dependencies": {
+          "System.Reflection.Metadata": "8.0.0"
+        }
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2024.2.0",
+        "contentHash": "9r+4UF2P51lTztpd+H7SJywk7WgmlWB//Cm2o96c6uGVZU5r58ys2/cD9pCgTk0zCdSkfflWL1WtqQ9I4IVO9Q==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.4.0"
+        }
+      },
+      "System.Collections.Immutable": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "AurL6Y5BA1WotzlEvVaIDpqzpIPvYnnldxru8oXJU2yFxFUy3+pNXjXd1ymO+RA0rq0+590Q8gaz2l3Sr7fmqg=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "0nlr0reXrRmkZNKifKqh2DgGhQgfkT7Qa3gQxIn/JI7/y3WDiTz67M+Sq3vFhUqcG8O5zVrpqHvIHeGPGUBsEw=="
+      },
+      "System.Reflection.Metadata": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0"
+        }
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "uWRgViw2yJAUyGxrzDLCc6fkzE2dZIoXxs8V6YjCujKsJuP0pnpYSlbm2/7tKd0SjBnMtwfDQhLenk3bXonVOA=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "elastic.semantickernel.connectors.elasticsearch": {
+        "type": "Project",
+        "dependencies": {
+          "Elastic.Clients.Elasticsearch": "[8.18.0, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[9.0.6, )",
+          "Microsoft.Extensions.VectorData.Abstractions": "[9.5.0, )",
+          "MinVer": "[6.0.0, )",
+          "System.Text.Json": "[9.0.6, )"
+        }
+      },
+      "vectordata.conformancetests": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "[9.6.0, )",
+          "Microsoft.Extensions.Configuration": "[8.0.0, )",
+          "Microsoft.Extensions.DependencyInjection": "[8.0.1, )",
+          "Microsoft.Extensions.VectorData.Abstractions": "[9.5.0, )",
+          "System.Linq.Async": "[6.0.1, )",
+          "xunit": "[2.9.3, )"
+        }
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[9.6.0, )",
+        "resolved": "9.6.0",
+        "contentHash": "xGO7rHg3qK8jRdriAxIrsH4voNemCf8GVmgdcPXI5gpZ6lZWqOEM4ZO8yfYxUmg7+URw2AY1h7Uc/H17g7X1Kw=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "CentralTransitive",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "0J/9YNXTMWSZP2p2+nvl8p71zpSwokZXZuJW+VjdErkegAnFdO1XlqtA62SJtgVYHdKu3uPxJHcMR/r35HwFBA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "CentralTransitive",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "BmANAnR5Xd4Oqw7yQ75xOAYODybZQRzdeNucg7kS5wWKd2PNnMdYtJ2Vciy0QLylRmv42DGl5+AFL9izA6F1Rw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "0Zn6nR/6g+90MxskZyOOMPQvnPnrrGu6bytPwkV+azDcTtCSuQ1+GJUrg8Klmnrjk1i6zMpw2lXijl+tw7Q3kA=="
+      },
+      "MinVer": {
+        "type": "CentralTransitive",
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "+/SsmiySsXJlvQLCGBqaZKNVt3s/Y/HbAdwtop7Km2CnuZbaScoqkWJEBQ5Cy9ebkn6kCYKrHsXgwrFdTgcb3g=="
+      },
+      "System.Linq.Async": {
+        "type": "CentralTransitive",
+        "requested": "[6.0.1, )",
+        "resolved": "6.0.1",
+        "contentHash": "0YhHcaroWpQ9UCot3Pizah7ryAzQhNvobLMSxeDIGmnXfkQn8u5owvpOH0K6EVB+z9L7u6Cc4W17Br/+jyttEQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "System.Text.Json": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "h+ZtYTyTnTh5Ju6mHCKb3FPGx4ylJZgm9W7Y2psUnkhQRPMOIxX+TCN0ZgaR/+Yea+93XHWAaMzYTar1/EHIPg==",
+        "dependencies": {
+          "System.IO.Pipelines": "9.0.6",
+          "System.Text.Encodings.Web": "9.0.6"
+        }
+      },
+      "xunit.abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      }
+    }
+  }
+}

--- a/Elastic.SemanticKernel.sln
+++ b/Elastic.SemanticKernel.sln
@@ -17,6 +17,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		NuGet.Config = NuGet.Config
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.SemanticKernel.Connectors.ElasticSearch.ConformanceTests", "Elastic.SemanticKernel.Connectors.ElasticSearch.ConformanceTests\Elastic.SemanticKernel.Connectors.ElasticSearch.ConformanceTests.csproj", "{A8DD8128-080F-2DF0-5763-99801D225251}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VectorData.ConformanceTests", "test\VectorData.ConformanceTests\VectorData.ConformanceTests.csproj", "{14BE8394-A3E6-7D6B-DD3A-45E7DAA52DDF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,6 +35,14 @@ Global
 		{038E7FD9-6F16-4024-A741-2328B5E2996C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{038E7FD9-6F16-4024-A741-2328B5E2996C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{038E7FD9-6F16-4024-A741-2328B5E2996C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A8DD8128-080F-2DF0-5763-99801D225251}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A8DD8128-080F-2DF0-5763-99801D225251}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A8DD8128-080F-2DF0-5763-99801D225251}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A8DD8128-080F-2DF0-5763-99801D225251}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14BE8394-A3E6-7D6B-DD3A-45E7DAA52DDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14BE8394-A3E6-7D6B-DD3A-45E7DAA52DDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14BE8394-A3E6-7D6B-DD3A-45E7DAA52DDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14BE8394-A3E6-7D6B-DD3A-45E7DAA52DDF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/test/README.txt
+++ b/test/README.txt
@@ -1,0 +1,1 @@
+Copied from https://github.com/microsoft/semantic-kernel/tree/dotnet-1.56.0

--- a/test/VectorData.ConformanceTests/CRUD/BatchConformanceTests.cs
+++ b/test/VectorData.ConformanceTests/CRUD/BatchConformanceTests.cs
@@ -1,0 +1,158 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorData.ConformanceTests.Models;
+using VectorData.ConformanceTests.Support;
+using VectorData.ConformanceTests.Xunit;
+using Xunit;
+
+namespace VectorData.ConformanceTests.CRUD;
+
+public abstract class BatchConformanceTests<TKey>(SimpleModelFixture<TKey> fixture) where TKey : notnull
+{
+    [ConditionalFact]
+    public virtual async Task GetBatchAsyncThrowsArgumentNullExceptionForNullKeys()
+    {
+        ArgumentNullException ex = await Assert.ThrowsAsync<ArgumentNullException>(() => fixture.Collection.GetAsync(keys: null!).ToArrayAsync().AsTask());
+        Assert.Equal("keys", ex.ParamName);
+    }
+
+    [ConditionalFact]
+    public virtual async Task GetBatchAsyncDoesNotThrowForEmptyBatch()
+    {
+        Assert.Empty(await fixture.Collection.GetAsync([]).ToArrayAsync());
+    }
+
+    [ConditionalFact]
+    public virtual Task GetBatchAsync_WithVectors()
+        => this.GetBatchAsyncReturnsInsertedRecords(includeVectors: true);
+
+    [ConditionalFact]
+    public virtual Task GetBatchAsync_WithoutVectors()
+        => this.GetBatchAsyncReturnsInsertedRecords(includeVectors: false);
+
+    private async Task GetBatchAsyncReturnsInsertedRecords(bool includeVectors)
+    {
+        var expectedRecords = fixture.TestData.Take(2); // the last two records can get deleted by other tests
+        var ids = expectedRecords.Select(record => record.Id);
+
+        var received = await fixture.Collection.GetAsync(ids, new() { IncludeVectors = includeVectors }).ToArrayAsync();
+
+        foreach (var record in expectedRecords)
+        {
+            record.AssertEqual(this.GetRecord(received, record.Id), includeVectors, fixture.TestStore.VectorsComparable);
+        }
+    }
+
+    [ConditionalFact]
+    public virtual async Task UpsertBatchAsyncThrowsArgumentNullExceptionForNullBatch()
+    {
+        ArgumentNullException ex = await Assert.ThrowsAsync<ArgumentNullException>(() => fixture.Collection.UpsertAsync(records: null!));
+        Assert.Equal("records", ex.ParamName);
+    }
+
+    [ConditionalFact]
+    public virtual async Task UpsertBatchAsyncDoesNotThrowForEmptyBatch()
+    {
+        await fixture.Collection.UpsertAsync([]);
+    }
+
+    [ConditionalFact]
+    public virtual async Task UpsertBatchAsyncCanInsertNewRecord()
+    {
+        var collection = fixture.Collection;
+        SimpleRecord<TKey>[] inserted = Enumerable.Range(0, 10).Select(i => new SimpleRecord<TKey>()
+        {
+            Id = fixture.GenerateNextKey<TKey>(),
+            Number = 100 + i,
+            Text = i.ToString(),
+            Floats = Enumerable.Range(0, SimpleRecord<TKey>.DimensionCount).Select(j => (float)(i + j)).ToArray()
+        }).ToArray();
+        var keys = inserted.Select(record => record.Id).ToArray();
+
+        Assert.Empty(await collection.GetAsync(keys).ToArrayAsync());
+        await collection.UpsertAsync(inserted);
+
+        var received = await collection.GetAsync(keys, new() { IncludeVectors = true }).ToArrayAsync();
+        foreach (var record in inserted)
+        {
+            record.AssertEqual(this.GetRecord(received, record.Id), includeVectors: true, fixture.TestStore.VectorsComparable);
+        }
+    }
+
+    [ConditionalFact]
+    public virtual async Task UpsertBatchAsyncCanUpdateExistingRecords()
+    {
+        SimpleRecord<TKey>[] inserted = Enumerable.Range(0, 10).Select(i => new SimpleRecord<TKey>()
+        {
+            Id = fixture.GenerateNextKey<TKey>(),
+            Number = 100 + i,
+            Text = i.ToString(),
+            Floats = Enumerable.Range(0, SimpleRecord<TKey>.DimensionCount).Select(j => (float)(i + j)).ToArray()
+        }).ToArray();
+        await fixture.Collection.UpsertAsync(inserted);
+
+        SimpleRecord<TKey>[] updated = inserted.Select(i => new SimpleRecord<TKey>()
+        {
+            Id = i.Id,
+            Text = i.Text + "updated",
+            Number = i.Number + 200,
+            Floats = i.Floats
+        }).ToArray();
+
+        await fixture.Collection.UpsertAsync(updated);
+    }
+
+    [ConditionalFact]
+    public virtual async Task UpsertCanBothInsertAndUpdateRecordsFromTheSameBatch()
+    {
+        SimpleRecord<TKey>[] records = Enumerable.Range(0, 10).Select(i => new SimpleRecord<TKey>()
+        {
+            Id = fixture.GenerateNextKey<TKey>(),
+            Number = 100 + i,
+            Text = i.ToString(),
+            Floats = Enumerable.Range(0, SimpleRecord<TKey>.DimensionCount).Select(j => (float)(i + j)).ToArray()
+        }).ToArray();
+
+        // We take first half of the records and insert them.
+        SimpleRecord<TKey>[] firstHalf = records.Take(records.Length / 2).ToArray();
+        await fixture.Collection.UpsertAsync(firstHalf);
+
+        // Now we modify the first half of the records.
+        foreach (var record in firstHalf)
+        {
+            record.Text += "updated";
+            record.Number += 200;
+        }
+
+        // And now we upsert all the records (the first half is an update, the second is an insert).
+        await fixture.Collection.UpsertAsync(records);
+    }
+
+    [ConditionalFact]
+    public virtual async Task DeleteBatchAsyncDoesNotThrowForEmptyBatch()
+    {
+        await fixture.Collection.DeleteAsync([]);
+    }
+
+    [ConditionalFact]
+    public virtual async Task DeleteBatchAsyncThrowsArgumentNullExceptionForNullKeys()
+    {
+        ArgumentNullException ex = await Assert.ThrowsAsync<ArgumentNullException>(() => fixture.Collection.DeleteAsync(keys: null!));
+        Assert.Equal("keys", ex.ParamName);
+    }
+
+    [ConditionalFact]
+    public virtual async Task DeleteBatchAsyncDeletesTheRecords()
+    {
+        TKey[] idsToRemove = [fixture.TestData[2].Id, fixture.TestData[3].Id];
+
+        Assert.NotEmpty(await fixture.Collection.GetAsync(idsToRemove).ToArrayAsync());
+        await fixture.Collection.DeleteAsync(idsToRemove);
+        Assert.Empty(await fixture.Collection.GetAsync(idsToRemove).ToArrayAsync());
+    }
+
+    // The order of records in the received array is not guaranteed
+    // to match the order of keys in the requested keys array.
+    protected SimpleRecord<TKey> GetRecord(SimpleRecord<TKey>[] received, TKey key)
+        => received.Single(r => r.Id!.Equals(key));
+}

--- a/test/VectorData.ConformanceTests/CRUD/DynamicDataModelConformanceTests.cs
+++ b/test/VectorData.ConformanceTests/CRUD/DynamicDataModelConformanceTests.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorData.ConformanceTests.Support;
+using VectorData.ConformanceTests.Xunit;
+using Xunit;
+
+namespace VectorData.ConformanceTests.CRUD;
+
+public abstract class DynamicDataModelConformanceTests<TKey>(DynamicDataModelFixture<TKey> fixture)
+    where TKey : notnull
+{
+    [ConditionalFact]
+    public virtual async Task GetAsyncThrowsArgumentNullExceptionForNullKey()
+    {
+        // Skip this test for value type keys
+        if (default(TKey) is not null)
+        {
+            return;
+        }
+
+        ArgumentNullException ex = await Assert.ThrowsAsync<ArgumentNullException>(() => fixture.Collection.GetAsync((TKey)default!));
+        Assert.Equal("key", ex.ParamName);
+    }
+
+    [ConditionalFact]
+    public virtual async Task GetAsyncReturnsNullForNonExistingKey()
+    {
+        TKey key = fixture.GenerateNextKey<TKey>();
+
+        Assert.Null(await fixture.Collection.GetAsync(key));
+    }
+
+    [ConditionalFact]
+    public virtual Task GetAsync_WithVectors()
+        => this.GetAsyncReturnsInsertedRecord(includeVectors: true);
+
+    [ConditionalFact]
+    public virtual Task GetAsync_WithoutVectors()
+        => this.GetAsyncReturnsInsertedRecord(includeVectors: false);
+
+    private async Task GetAsyncReturnsInsertedRecord(bool includeVectors)
+    {
+        var expectedRecord = fixture.TestData[0];
+
+        var received = await fixture.Collection.GetAsync(
+            (TKey)expectedRecord[DynamicDataModelFixture<TKey>.KeyPropertyName]!,
+            new() { IncludeVectors = includeVectors });
+
+        AssertEquivalent(expectedRecord, received, includeVectors, fixture.TestStore.VectorsComparable);
+    }
+
+    [ConditionalFact]
+    public virtual async Task UpsertAsyncCanInsertNewRecord()
+    {
+        var collection = fixture.Collection;
+        TKey expectedKey = fixture.GenerateNextKey<TKey>();
+        var inserted = new Dictionary<string, object?>
+        {
+            [DynamicDataModelFixture<TKey>.KeyPropertyName] = expectedKey,
+            [DynamicDataModelFixture<TKey>.StringPropertyName] = "some",
+            [DynamicDataModelFixture<TKey>.IntegerPropertyName] = 123,
+            [DynamicDataModelFixture<TKey>.EmbeddingPropertyName] = new ReadOnlyMemory<float>(Enumerable.Repeat(0.1f, DynamicDataModelFixture<TKey>.DimensionCount).ToArray())
+        };
+
+        Assert.Null(await collection.GetAsync(expectedKey));
+        await collection.UpsertAsync(inserted);
+
+        var received = await collection.GetAsync(expectedKey, new() { IncludeVectors = true });
+        AssertEquivalent(inserted, received, includeVectors: true, fixture.TestStore.VectorsComparable);
+    }
+
+    [ConditionalFact]
+    public virtual async Task UpsertAsyncCanUpdateExistingRecord()
+    {
+        var collection = fixture.Collection;
+        var existingRecord = fixture.TestData[1];
+        var updated = new Dictionary<string, object?>
+        {
+            [DynamicDataModelFixture<TKey>.KeyPropertyName] = existingRecord[DynamicDataModelFixture<TKey>.KeyPropertyName],
+            [DynamicDataModelFixture<TKey>.StringPropertyName] = "different",
+            [DynamicDataModelFixture<TKey>.IntegerPropertyName] = 456,
+            [DynamicDataModelFixture<TKey>.EmbeddingPropertyName] = new ReadOnlyMemory<float>(Enumerable.Repeat(0.7f, DynamicDataModelFixture<TKey>.DimensionCount).ToArray())
+        };
+
+        Assert.NotNull(await collection.GetAsync((TKey)existingRecord[DynamicDataModelFixture<TKey>.KeyPropertyName]!));
+        await collection.UpsertAsync(updated);
+
+        var received = await collection.GetAsync((TKey)existingRecord[DynamicDataModelFixture<TKey>.KeyPropertyName]!, new() { IncludeVectors = true });
+        AssertEquivalent(updated, received, includeVectors: true, fixture.TestStore.VectorsComparable);
+    }
+
+    [ConditionalFact]
+    public virtual async Task DeleteAsyncDoesNotThrowForNonExistingKey()
+    {
+        TKey key = fixture.GenerateNextKey<TKey>();
+
+        await fixture.Collection.DeleteAsync(key);
+    }
+
+    [ConditionalFact]
+    public async Task DeleteAsyncDeletesTheRecord()
+    {
+        var recordToRemove = fixture.TestData[2];
+
+        Assert.NotNull(await fixture.Collection.GetAsync((TKey)recordToRemove[DynamicDataModelFixture<TKey>.KeyPropertyName]!));
+        await fixture.Collection.DeleteAsync((TKey)recordToRemove[DynamicDataModelFixture<TKey>.KeyPropertyName]!);
+        Assert.Null(await fixture.Collection.GetAsync((TKey)recordToRemove[DynamicDataModelFixture<TKey>.KeyPropertyName]!));
+    }
+
+    protected static void AssertEquivalent(Dictionary<string, object?> expected, Dictionary<string, object?>? actual, bool includeVectors, bool compareVectors)
+    {
+        Assert.NotNull(actual);
+        Assert.Equal(expected[DynamicDataModelFixture<TKey>.KeyPropertyName], actual[DynamicDataModelFixture<TKey>.KeyPropertyName]);
+
+        Assert.Equal(expected[DynamicDataModelFixture<TKey>.StringPropertyName], actual[DynamicDataModelFixture<TKey>.StringPropertyName]);
+        Assert.Equal(expected[DynamicDataModelFixture<TKey>.IntegerPropertyName], actual[DynamicDataModelFixture<TKey>.IntegerPropertyName]);
+
+        if (includeVectors)
+        {
+            Assert.Equal(
+                ((ReadOnlyMemory<float>)expected[DynamicDataModelFixture<TKey>.EmbeddingPropertyName]!).Length,
+                ((ReadOnlyMemory<float>)actual[DynamicDataModelFixture<TKey>.EmbeddingPropertyName]!).Length);
+
+            if (compareVectors)
+            {
+                Assert.Equal(
+                    ((ReadOnlyMemory<float>)expected[DynamicDataModelFixture<TKey>.EmbeddingPropertyName]!).ToArray(),
+                    ((ReadOnlyMemory<float>)actual[DynamicDataModelFixture<TKey>.EmbeddingPropertyName]!).ToArray());
+            }
+        }
+        else
+        {
+            Assert.False(actual.ContainsKey(DynamicDataModelFixture<TKey>.EmbeddingPropertyName));
+        }
+    }
+}

--- a/test/VectorData.ConformanceTests/CRUD/NoDataConformanceTests.cs
+++ b/test/VectorData.ConformanceTests/CRUD/NoDataConformanceTests.cs
@@ -1,0 +1,182 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+using VectorData.ConformanceTests.Support;
+using VectorData.ConformanceTests.Xunit;
+using Xunit;
+
+namespace VectorData.ConformanceTests.CRUD;
+
+/// <summary>
+/// Tests CRUD operations using a model without data fields.
+/// </summary>
+public class NoDataConformanceTests<TKey>(NoDataConformanceTests<TKey>.Fixture fixture) where TKey : notnull
+{
+    [ConditionalFact]
+    public virtual Task GetAsyncReturnsInsertedRecord_WithVectors()
+        => this.GetAsyncReturnsInsertedRecord(includeVectors: true);
+
+    [ConditionalFact]
+    public virtual Task GetAsyncReturnsInsertedRecord_WithoutVectors()
+        => this.GetAsyncReturnsInsertedRecord(includeVectors: false);
+
+    private async Task GetAsyncReturnsInsertedRecord(bool includeVectors)
+    {
+        var expectedRecord = fixture.TestData[0];
+
+        var received = await fixture.Collection.GetAsync(expectedRecord.Id, new() { IncludeVectors = includeVectors });
+
+        expectedRecord.AssertEqual(received, includeVectors, fixture.TestStore.VectorsComparable);
+    }
+
+    [ConditionalFact]
+    public virtual Task UpsertAsyncCanInsertNewRecord_WithVectors()
+        => this.UpsertAsyncCanInsertNewRecord(includeVectors: true);
+
+    [ConditionalFact]
+    public virtual Task UpsertAsyncCanInsertNewRecord_WithoutVectors()
+        => this.UpsertAsyncCanInsertNewRecord(includeVectors: false);
+
+    private async Task UpsertAsyncCanInsertNewRecord(bool includeVectors)
+    {
+        var collection = fixture.Collection;
+        TKey expectedKey = fixture.GenerateNextKey<TKey>();
+        NoDataRecord inserted = new()
+        {
+            Id = expectedKey,
+            Floats = new ReadOnlyMemory<float>(Enumerable.Repeat(0.1f, NoDataRecord.DimensionCount).ToArray())
+        };
+
+        Assert.Null(await collection.GetAsync(expectedKey));
+        await collection.UpsertAsync(inserted);
+
+        var received = await collection.GetAsync(expectedKey, new() { IncludeVectors = includeVectors });
+        inserted.AssertEqual(received, includeVectors, fixture.TestStore.VectorsComparable);
+    }
+
+    [ConditionalFact]
+    public virtual Task UpsertAsyncCanUpdateExistingRecord_WithVectors()
+        => this.UpsertAsyncCanUpdateExistingRecord(includeVectors: true);
+
+    [ConditionalFact]
+    public virtual Task UpsertAsyncCanUpdateExistingRecord_WithoutVectors()
+        => this.UpsertAsyncCanUpdateExistingRecord(includeVectors: false);
+
+    private async Task UpsertAsyncCanUpdateExistingRecord(bool includeVectors)
+    {
+        var collection = fixture.Collection;
+        var existingRecord = fixture.TestData[1];
+        NoDataRecord updated = new()
+        {
+            Id = existingRecord.Id,
+            Floats = new ReadOnlyMemory<float>(Enumerable.Repeat(0.25f, NoDataRecord.DimensionCount).ToArray())
+        };
+
+        Assert.NotNull(await collection.GetAsync(existingRecord.Id, new() { IncludeVectors = true }));
+        await collection.UpsertAsync(updated);
+
+        var received = await collection.GetAsync(existingRecord.Id, new() { IncludeVectors = includeVectors });
+        updated.AssertEqual(received, includeVectors, fixture.TestStore.VectorsComparable);
+    }
+
+    [ConditionalFact]
+    public virtual async Task DeleteAsyncDeletesTheRecord()
+    {
+        var recordToRemove = fixture.TestData[2];
+
+        Assert.NotNull(await fixture.Collection.GetAsync(recordToRemove.Id, new() { IncludeVectors = true }));
+        await fixture.Collection.DeleteAsync(recordToRemove.Id);
+        Assert.Null(await fixture.Collection.GetAsync(recordToRemove.Id));
+    }
+
+    /// <summary>
+    /// This class is for testing databases that support having no data fields.
+    /// </summary>
+    public sealed class NoDataRecord
+    {
+        public const int DimensionCount = 3;
+
+        [VectorStoreKey(StorageName = "key")]
+        public TKey Id { get; set; } = default!;
+
+        [VectorStoreVector(DimensionCount, StorageName = "embedding")]
+        public ReadOnlyMemory<float> Floats { get; set; }
+
+        public void AssertEqual(NoDataRecord? other, bool includeVectors, bool compareVectors)
+        {
+            Assert.NotNull(other);
+            Assert.Equal(this.Id, other.Id);
+
+            if (includeVectors)
+            {
+                Assert.Equal(this.Floats.Span.Length, other.Floats.Span.Length);
+
+                if (compareVectors)
+                {
+                    Assert.True(this.Floats.Span.SequenceEqual(other.Floats.Span));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Provides data and configuration for a model without data fields.
+    /// </summary>
+    public abstract class Fixture : VectorStoreCollectionFixture<TKey, NoDataRecord>
+    {
+        protected override List<NoDataRecord> BuildTestData() =>
+        [
+            new()
+            {
+                Id = this.GenerateNextKey<TKey>(),
+                Floats = new ReadOnlyMemory<float>(Enumerable.Repeat(0.1f, NoDataRecord.DimensionCount).ToArray())
+            },
+            new()
+            {
+                Id = this.GenerateNextKey<TKey>(),
+                Floats = new ReadOnlyMemory<float>(Enumerable.Repeat(0.2f, NoDataRecord.DimensionCount).ToArray())
+            },
+            new()
+            {
+                Id = this.GenerateNextKey<TKey>(),
+                Floats = new ReadOnlyMemory<float>(Enumerable.Repeat(0.3f, NoDataRecord.DimensionCount).ToArray())
+            },
+            new()
+            {
+                Id = this.GenerateNextKey<TKey>(),
+                Floats = new ReadOnlyMemory<float>(Enumerable.Repeat(0.4f, NoDataRecord.DimensionCount).ToArray())
+            }
+        ];
+
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
+            => new()
+            {
+                Properties =
+                [
+                    new VectorStoreKeyProperty(nameof(NoDataRecord.Id), typeof(TKey)) { StorageName = "key" },
+                    new VectorStoreVectorProperty(nameof(NoDataRecord.Floats), typeof(ReadOnlyMemory<float>), NoDataRecord.DimensionCount)
+                    {
+                        StorageName = "embedding",
+                        IndexKind = this.IndexKind,
+                    }
+                ]
+            };
+
+        protected override async Task WaitForDataAsync()
+        {
+            for (var i = 0; i < 20; i++)
+            {
+                var getOptions = new RecordRetrievalOptions { IncludeVectors = true };
+                var results = await this.Collection.GetAsync([this.TestData[0].Id, this.TestData[1].Id, this.TestData[2].Id, this.TestData[3].Id], getOptions).ToArrayAsync();
+                if (results.Length == 4 && results.All(r => r != null))
+                {
+                    return;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+            }
+
+            throw new InvalidOperationException("Data did not appear in the collection within the expected time.");
+        }
+    }
+}

--- a/test/VectorData.ConformanceTests/CRUD/NoVectorConformanceTests.cs
+++ b/test/VectorData.ConformanceTests/CRUD/NoVectorConformanceTests.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+using VectorData.ConformanceTests.Support;
+using VectorData.ConformanceTests.Xunit;
+using Xunit;
+
+namespace VectorData.ConformanceTests.CRUD;
+
+/// <summary>
+/// Tests CRUD operations using a model without a vector.
+/// This is only supported by a subset of databases so only extend if applicable for your database.
+/// </summary>
+public class NoVectorConformanceTests<TKey>(NoVectorConformanceTests<TKey>.Fixture fixture) where TKey : notnull
+{
+    [ConditionalFact]
+    public Task GetAsyncReturnsInsertedRecord_WithVectors()
+        => this.GetAsyncReturnsInsertedRecord(includeVectors: true);
+
+    [ConditionalFact]
+    public Task GetAsyncReturnsInsertedRecord_WithoutVectors()
+        => this.GetAsyncReturnsInsertedRecord(includeVectors: false);
+
+    private async Task GetAsyncReturnsInsertedRecord(bool includeVectors)
+    {
+        var expectedRecord = fixture.TestData[0];
+
+        var received = await fixture.Collection.GetAsync(expectedRecord.Id, new() { IncludeVectors = includeVectors });
+
+        expectedRecord.AssertEqual(received);
+    }
+
+    [ConditionalFact]
+    public Task UpsertAsyncCanInsertNewRecord_WithVectors()
+        => this.UpsertAsyncCanInsertNewRecord(includeVectors: true);
+
+    [ConditionalFact]
+    public Task UpsertAsyncCanInsertNewRecord_WithoutVectors()
+        => this.UpsertAsyncCanInsertNewRecord(includeVectors: false);
+
+    private async Task UpsertAsyncCanInsertNewRecord(bool includeVectors)
+    {
+        var collection = fixture.Collection;
+        TKey expectedKey = fixture.GenerateNextKey<TKey>();
+        NoVectorRecord inserted = new()
+        {
+            Id = expectedKey,
+            Text = "some"
+        };
+
+        Assert.Null(await collection.GetAsync(expectedKey));
+        await collection.UpsertAsync(inserted);
+
+        var received = await collection.GetAsync(expectedKey, new() { IncludeVectors = includeVectors });
+        inserted.AssertEqual(received);
+    }
+
+    [ConditionalFact]
+    public Task UpsertAsyncCanUpdateExistingRecord_WithVectors()
+        => this.UpsertAsyncCanUpdateExistingRecord(includeVectors: true);
+
+    [ConditionalFact]
+    public Task UpsertAsyncCanUpdateExistingRecord__WithoutVectors()
+        => this.UpsertAsyncCanUpdateExistingRecord(includeVectors: false);
+
+    private async Task UpsertAsyncCanUpdateExistingRecord(bool includeVectors)
+    {
+        var collection = fixture.Collection;
+        var existingRecord = fixture.TestData[1];
+        NoVectorRecord updated = new()
+        {
+            Id = existingRecord.Id,
+            Text = "updated"
+        };
+
+        Assert.NotNull(await collection.GetAsync(existingRecord.Id));
+        await collection.UpsertAsync(updated);
+
+        var received = await collection.GetAsync(existingRecord.Id, new() { IncludeVectors = includeVectors });
+        updated.AssertEqual(received);
+    }
+
+    [ConditionalFact]
+    public async Task DeleteAsyncDeletesTheRecord()
+    {
+        var recordToRemove = fixture.TestData[2];
+
+        Assert.NotNull(await fixture.Collection.GetAsync(recordToRemove.Id));
+        await fixture.Collection.DeleteAsync(recordToRemove.Id);
+        Assert.Null(await fixture.Collection.GetAsync(recordToRemove.Id));
+    }
+
+    /// <summary>
+    /// This class is for testing databases that support having no vector.
+    /// Not all DBs support this.
+    /// </summary>
+    public sealed class NoVectorRecord
+    {
+        public const int DimensionCount = 3;
+
+        [VectorStoreKey(StorageName = "key")]
+        public TKey Id { get; set; } = default!;
+
+        [VectorStoreData(StorageName = "text")]
+        public string? Text { get; set; }
+
+        public void AssertEqual(NoVectorRecord? other)
+        {
+            Assert.NotNull(other);
+            Assert.Equal(this.Id, other.Id);
+            Assert.Equal(this.Text, other.Text);
+        }
+    }
+
+    /// <summary>
+    /// Provides data and configuration for a model without a vector, which is supported by some connectors.
+    /// </summary>
+    public abstract class Fixture : VectorStoreCollectionFixture<TKey, NoVectorRecord>
+    {
+        protected override List<NoVectorRecord> BuildTestData() =>
+        [
+            new()
+            {
+                Id = this.GenerateNextKey<TKey>(),
+                Text = "UsedByGetTests",
+            },
+            new()
+            {
+                Id = this.GenerateNextKey<TKey>(),
+                Text = "UsedByUpdateTests",
+            },
+            new()
+            {
+                Id = this.GenerateNextKey<TKey>(),
+                Text = "UsedByDeleteTests",
+            },
+            new()
+            {
+                Id = this.GenerateNextKey<TKey>(),
+                Text = "UsedByDeleteBatchTests",
+            }
+        ];
+
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
+            => new()
+            {
+                Properties =
+                [
+                    new VectorStoreKeyProperty(nameof(NoVectorRecord.Id), typeof(TKey)) { StorageName = "key" },
+                    new VectorStoreDataProperty(nameof(NoVectorRecord.Text), typeof(string)) { IsIndexed = true, StorageName = "text" },
+                ]
+            };
+
+        protected override async Task WaitForDataAsync()
+        {
+            for (var i = 0; i < 20; i++)
+            {
+                var results = await this.Collection.GetAsync([this.TestData[0].Id, this.TestData[1].Id, this.TestData[2].Id, this.TestData[3].Id]).ToArrayAsync();
+                if (results.Length == 4 && results.All(r => r != null))
+                {
+                    return;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+            }
+
+            throw new InvalidOperationException("Data did not appear in the collection within the expected time.");
+        }
+    }
+}

--- a/test/VectorData.ConformanceTests/CRUD/RecordConformanceTests.cs
+++ b/test/VectorData.ConformanceTests/CRUD/RecordConformanceTests.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using VectorData.ConformanceTests.Models;
+using VectorData.ConformanceTests.Support;
+using VectorData.ConformanceTests.Xunit;
+using Xunit;
+
+namespace VectorData.ConformanceTests.CRUD;
+
+public class RecordConformanceTests<TKey>(SimpleModelFixture<TKey> fixture) where TKey : notnull
+{
+    [ConditionalFact]
+    public virtual async Task GetAsyncThrowsArgumentNullExceptionForNullKey()
+    {
+        // Skip this test for value type keys
+        if (default(TKey) is not null)
+        {
+            return;
+        }
+
+        ArgumentNullException ex = await Assert.ThrowsAsync<ArgumentNullException>(() => fixture.Collection.GetAsync((TKey)default!));
+        Assert.Equal("key", ex.ParamName);
+    }
+
+    [ConditionalFact]
+    public virtual async Task GetAsyncReturnsNullForNonExistingKey()
+    {
+        TKey key = fixture.GenerateNextKey<TKey>();
+
+        Assert.Null(await fixture.Collection.GetAsync(key));
+    }
+
+    [ConditionalFact]
+    public virtual Task GetAsync_WithVectors()
+        => this.GetAsyncReturnsInsertedRecord(includeVectors: true);
+
+    [ConditionalFact]
+    public virtual Task GetAsync_WithoutVectors()
+        => this.GetAsyncReturnsInsertedRecord(includeVectors: false);
+
+    private async Task GetAsyncReturnsInsertedRecord(bool includeVectors)
+    {
+        var expectedRecord = fixture.TestData[0];
+
+        var received = await fixture.Collection.GetAsync(expectedRecord.Id, new() { IncludeVectors = includeVectors });
+
+        expectedRecord.AssertEqual(received, includeVectors, fixture.TestStore.VectorsComparable);
+    }
+
+    [ConditionalFact]
+    public virtual async Task UpsertAsyncCanInsertNewRecord()
+    {
+        var collection = fixture.Collection;
+        TKey expectedKey = fixture.GenerateNextKey<TKey>();
+        SimpleRecord<TKey> inserted = new()
+        {
+            Id = expectedKey,
+            Text = "some",
+            Number = 123,
+            Floats = new ReadOnlyMemory<float>(Enumerable.Repeat(0.1f, SimpleRecord<TKey>.DimensionCount).ToArray())
+        };
+
+        Assert.Null(await collection.GetAsync(expectedKey));
+        await collection.UpsertAsync(inserted);
+
+        var received = await collection.GetAsync(expectedKey, new() { IncludeVectors = true });
+        inserted.AssertEqual(received, includeVectors: true, fixture.TestStore.VectorsComparable);
+    }
+
+    [ConditionalFact]
+    public virtual async Task UpsertAsyncCanUpdateExistingRecord()
+    {
+        var collection = fixture.Collection;
+        var existingRecord = fixture.TestData[1];
+        SimpleRecord<TKey> updated = new()
+        {
+            Id = existingRecord.Id,
+            Text = "updated",
+            Number = 456,
+            Floats = new ReadOnlyMemory<float>(Enumerable.Repeat(0.25f, SimpleRecord<TKey>.DimensionCount).ToArray())
+        };
+
+        Assert.NotNull(await collection.GetAsync(existingRecord.Id));
+        await collection.UpsertAsync(updated);
+
+        var received = await collection.GetAsync(existingRecord.Id, new() { IncludeVectors = true });
+        updated.AssertEqual(received, includeVectors: true, fixture.TestStore.VectorsComparable);
+    }
+
+    [ConditionalFact]
+    public virtual async Task DeleteAsyncDoesNotThrowForNonExistingKey()
+    {
+        TKey key = fixture.GenerateNextKey<TKey>();
+
+        await fixture.Collection.DeleteAsync(key);
+    }
+
+    [ConditionalFact]
+    public virtual async Task DeleteAsyncDeletesTheRecord()
+    {
+        var recordToRemove = fixture.TestData[2];
+
+        Assert.NotNull(await fixture.Collection.GetAsync(recordToRemove.Id));
+        await fixture.Collection.DeleteAsync(recordToRemove.Id);
+        Assert.Null(await fixture.Collection.GetAsync(recordToRemove.Id));
+    }
+}

--- a/test/VectorData.ConformanceTests/Collections/CollectionConformanceTests.cs
+++ b/test/VectorData.ConformanceTests/Collections/CollectionConformanceTests.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+using VectorData.ConformanceTests.Models;
+using VectorData.ConformanceTests.Support;
+using VectorData.ConformanceTests.Xunit;
+using Xunit;
+
+namespace VectorData.ConformanceTests.Collections;
+
+public abstract class CollectionConformanceTests<TKey>(VectorStoreFixture fixture) : IAsyncLifetime
+    where TKey : notnull
+{
+    public Task InitializeAsync()
+        => fixture.VectorStore.EnsureCollectionDeletedAsync(this.CollectionName);
+
+    [ConditionalFact]
+    public async Task Collection_Ensure_Exists_Delete()
+    {
+        var collection = this.GetCollection();
+
+        Assert.False(await collection.CollectionExistsAsync());
+        await collection.EnsureCollectionExistsAsync();
+        Assert.True(await collection.CollectionExistsAsync());
+        await collection.EnsureCollectionDeletedAsync();
+        Assert.False(await collection.CollectionExistsAsync());
+
+        // Deleting a non-existing collection does not throw
+        await fixture.TestStore.DefaultVectorStore.EnsureCollectionDeletedAsync(collection.Name);
+    }
+
+    [ConditionalFact]
+    public async Task EnsureCollectionExists_twice_does_not_throw()
+    {
+        var collection = this.GetCollection();
+
+        await collection.EnsureCollectionExistsAsync();
+        await collection.EnsureCollectionExistsAsync();
+        Assert.True(await collection.CollectionExistsAsync());
+    }
+
+    [ConditionalFact]
+    public async Task Store_CollectionExists()
+    {
+        var store = fixture.VectorStore;
+        var collection = this.GetCollection();
+
+        Assert.False(await store.CollectionExistsAsync(collection.Name));
+        await collection.EnsureCollectionExistsAsync();
+        Assert.True(await store.CollectionExistsAsync(collection.Name));
+    }
+
+    [ConditionalFact]
+    public async Task Store_DeleteCollection()
+    {
+        var store = fixture.VectorStore;
+        var collection = this.GetCollection();
+
+        await collection.EnsureCollectionExistsAsync();
+        await fixture.TestStore.DefaultVectorStore.EnsureCollectionDeletedAsync(collection.Name);
+        Assert.False(await collection.CollectionExistsAsync());
+    }
+
+    [ConditionalFact]
+    public async Task Store_ListCollections()
+    {
+        var store = fixture.VectorStore;
+        var collection = this.GetCollection();
+
+        Assert.Empty(await store.ListCollectionNamesAsync().Where(n => n == collection.Name).ToListAsync());
+
+        await collection.EnsureCollectionExistsAsync();
+
+        var name = Assert.Single(await store.ListCollectionNamesAsync().Where(n => n == collection.Name).ToListAsync());
+        Assert.Equal(collection.Name, name);
+    }
+
+    [ConditionalFact]
+    public void Collection_metadata()
+    {
+        var collection = this.GetCollection();
+
+        var collectionMetadata = (VectorStoreCollectionMetadata?)collection.GetService(typeof(VectorStoreCollectionMetadata));
+
+        Assert.NotNull(collectionMetadata);
+        Assert.NotNull(collectionMetadata.VectorStoreSystemName);
+        Assert.NotNull(collectionMetadata.CollectionName);
+    }
+
+    public virtual string CollectionName => "CollectionTests";
+
+    public virtual VectorStoreCollection<TKey, SimpleRecord<TKey>> GetCollection()
+        => fixture.TestStore.DefaultVectorStore.GetCollection<TKey, SimpleRecord<TKey>>(this.CollectionName, this.CreateRecordDefinition());
+
+    public virtual VectorStoreCollectionDefinition CreateRecordDefinition()
+        => new()
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(nameof(SimpleRecord<object>.Id), typeof(TKey)) { StorageName = "key" },
+                new VectorStoreDataProperty(nameof(SimpleRecord<object>.Text), typeof(string)) { StorageName = "text" },
+                new VectorStoreDataProperty(nameof(SimpleRecord<object>.Number), typeof(int)) { StorageName = "number" },
+                new VectorStoreVectorProperty(nameof(SimpleRecord<object>.Floats), typeof(ReadOnlyMemory<float>), 10) { IndexKind = fixture.TestStore.DefaultIndexKind }
+            ]
+        };
+
+    public Task DisposeAsync() => Task.CompletedTask;
+}

--- a/test/VectorData.ConformanceTests/DependencyInjectionTests.cs
+++ b/test/VectorData.ConformanceTests/DependencyInjectionTests.cs
@@ -1,0 +1,266 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq.Expressions;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.VectorData;
+using Xunit;
+
+namespace VectorData.ConformanceTests;
+
+public abstract class DependencyInjectionTests<TVectorStore, TCollection, TKey, TRecord>
+    where TVectorStore : VectorStore
+    where TCollection : VectorStoreCollection<TKey, TRecord>
+    where TKey : notnull
+    where TRecord : class
+{
+    protected virtual string CollectionName => "collectionName";
+
+    protected abstract void PopulateConfiguration(ConfigurationManager configuration, object? serviceKey = null);
+
+    public abstract IEnumerable<Func<IServiceCollection, object?, ServiceLifetime, IServiceCollection>> StoreDelegates { get; }
+
+    public abstract IEnumerable<Func<IServiceCollection, object?, string, ServiceLifetime, IServiceCollection>> CollectionDelegates { get; }
+
+    [Fact]
+    public void ServiceCollectionCantBeNull()
+    {
+        foreach (var registrationDelegate in this.StoreDelegates)
+        {
+            Assert.Throws<ArgumentNullException>(() => registrationDelegate(null!, null, ServiceLifetime.Singleton));
+            Assert.Throws<ArgumentNullException>(() => registrationDelegate(null!, "serviceKey", ServiceLifetime.Singleton));
+        }
+
+        foreach (var registrationDelegate in this.CollectionDelegates)
+        {
+            Assert.Throws<ArgumentNullException>(() => registrationDelegate(null!, null, this.CollectionName, ServiceLifetime.Singleton));
+            Assert.Throws<ArgumentNullException>(() => registrationDelegate(null!, "serviceKey", this.CollectionName, ServiceLifetime.Singleton));
+        }
+    }
+
+    [Fact]
+    public void CollectionNameCantBeNullOrEmpty()
+    {
+        const string EmptyCollectionName = "";
+
+        foreach (var registrationDelegate in this.CollectionDelegates)
+        {
+            IServiceCollection services = this.CreateServices();
+
+            Assert.Throws<ArgumentNullException>(() => registrationDelegate(services, null, null!, ServiceLifetime.Singleton));
+            Assert.Throws<ArgumentNullException>(() => registrationDelegate(services, "serviceKey", null!, ServiceLifetime.Singleton));
+            Assert.Throws<ArgumentException>(() => registrationDelegate(services, null, EmptyCollectionName, ServiceLifetime.Singleton));
+            Assert.Throws<ArgumentException>(() => registrationDelegate(services, "serviceKey", EmptyCollectionName, ServiceLifetime.Singleton));
+        }
+    }
+
+#pragma warning disable CA1000 // Do not declare static members on generic types
+    public static IEnumerable<object?[]> LifetimesAndServiceKeys()
+#pragma warning restore CA1000 // Do not declare static members on generic types
+    {
+        foreach (ServiceLifetime lifetime in new ServiceLifetime[] { ServiceLifetime.Scoped, ServiceLifetime.Singleton, ServiceLifetime.Transient })
+        {
+            yield return new object?[] { lifetime, null };
+            yield return new object?[] { lifetime, "key" };
+            yield return new object?[] { lifetime, 8 };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LifetimesAndServiceKeys))]
+    public virtual void CanRegisterVectorStore(ServiceLifetime lifetime, object? serviceKey)
+    {
+        foreach (var registrationDelegate in this.StoreDelegates)
+        {
+            IServiceCollection services = this.CreateServices(serviceKey);
+
+            registrationDelegate(services, serviceKey, lifetime);
+
+            using ServiceProvider serviceProvider = services.BuildServiceProvider();
+            // let's ensure that concrete types are registered
+            Verify<TVectorStore>(serviceProvider, lifetime, serviceKey);
+            // and the abstraction too
+            Verify<VectorStore>(serviceProvider, lifetime, serviceKey);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LifetimesAndServiceKeys))]
+    public void CanRegisterCollections(ServiceLifetime lifetime, object? serviceKey)
+    {
+        foreach (var registrationDelegate in this.CollectionDelegates)
+        {
+            IServiceCollection services = this.CreateServices(serviceKey);
+
+            registrationDelegate(services, serviceKey, this.CollectionName, lifetime);
+
+            using ServiceProvider serviceProvider = services.BuildServiceProvider();
+            // Let's ensure that concrete types are registered.
+            Verify<TCollection>(serviceProvider, lifetime, serviceKey);
+            // And the VectorStoreCollection abstraction.
+            Verify<VectorStoreCollection<TKey, TRecord>>(serviceProvider, lifetime, serviceKey);
+            // And the IVectorSearchable abstraction.
+            Verify<IVectorSearchable<TRecord>>(serviceProvider, lifetime, serviceKey);
+
+            if (typeof(IKeywordHybridSearchable<TRecord>).IsAssignableFrom(typeof(TCollection)))
+            {
+                Verify<IKeywordHybridSearchable<TRecord>>(serviceProvider, lifetime, serviceKey);
+            }
+            else
+            {
+                Assert.Null(serviceProvider.GetService<IKeywordHybridSearchable<TRecord>>());
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LifetimesAndServiceKeys))]
+    public virtual void CanRegisterConcreteTypeVectorStoreAfterSomeAbstractionHasBeenRegistered(ServiceLifetime lifetime, object? serviceKey)
+    {
+        foreach (var registrationDelegate in this.StoreDelegates)
+        {
+            IServiceCollection services = this.CreateServices(serviceKey);
+
+            // Users may be willing to register more than one IVectorStore implementation.
+            services.Add(new ServiceDescriptor(typeof(VectorStore), serviceKey, (sp, key) => new FakeVectorStore(), lifetime));
+
+            registrationDelegate(services, serviceKey, lifetime);
+
+            using ServiceProvider serviceProvider = services.BuildServiceProvider();
+            // let's ensure that concrete types are registered
+            Verify<TVectorStore>(serviceProvider, lifetime, serviceKey);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LifetimesAndServiceKeys))]
+    public void CanRegisterConcreteTypeCollectionsAfterSomeAbstractionHasBeenRegistered(ServiceLifetime lifetime, object? serviceKey)
+    {
+        foreach (var registrationDelegate in this.CollectionDelegates)
+        {
+            IServiceCollection services = this.CreateServices(serviceKey);
+
+            // Users may be willing to register more than one VectorStoreCollection implementation.
+            services.Add(new ServiceDescriptor(typeof(VectorStoreCollection<TKey, TRecord>), serviceKey, (sp, key) => new FakeVectorStoreRecordCollection(), lifetime));
+
+            registrationDelegate(services, serviceKey, this.CollectionName, lifetime);
+
+            using ServiceProvider serviceProvider = services.BuildServiceProvider();
+            // let's ensure that concrete types are registered
+            Verify<TCollection>(serviceProvider, lifetime, serviceKey);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(LifetimesAndServiceKeys))]
+    public void EmbeddingGeneratorIsResolved(ServiceLifetime lifetime, object? serviceKey)
+    {
+        foreach (var registrationDelegate in this.CollectionDelegates)
+        {
+            IServiceCollection services = this.CreateServices(serviceKey);
+
+            bool wasResolved = false;
+            services.AddSingleton<IEmbeddingGenerator>(sp =>
+            {
+                wasResolved = true;
+                return null!;
+            });
+
+            registrationDelegate(services, serviceKey, this.CollectionName, lifetime);
+
+            Assert.False(wasResolved); // it's lazy
+
+            using ServiceProvider serviceProvider = services.BuildServiceProvider();
+            using var collection = serviceKey is null
+                ? serviceProvider.GetRequiredService<TCollection>()
+                : serviceProvider.GetRequiredKeyedService<TCollection>(serviceKey);
+
+            Assert.True(wasResolved);
+        }
+    }
+
+    protected IServiceCollection CreateServices(object? serviceKey = null)
+    {
+        IServiceCollection services = new ServiceCollection();
+#pragma warning disable CA2000 // Dispose objects before losing scope
+        ConfigurationManager configuration = new();
+#pragma warning restore CA2000 // Dispose objects before losing scope
+        services.AddSingleton<IConfiguration>(configuration);
+
+        this.PopulateConfiguration(configuration, serviceKey);
+
+        return services;
+    }
+
+    private static void Verify<TService>(ServiceProvider serviceProvider, ServiceLifetime lifetime, object? serviceKey)
+        where TService : class
+    {
+        TService? serviceFromFirstScope, serviceFromSecondScope, secondServiceFromSecondScope;
+
+        using (IServiceScope scope1 = serviceProvider.CreateScope())
+        {
+            serviceFromFirstScope = Resolve<TService>(scope1.ServiceProvider, serviceKey);
+        }
+
+        using (IServiceScope scope2 = serviceProvider.CreateScope())
+        {
+            serviceFromSecondScope = Resolve<TService>(scope2.ServiceProvider, serviceKey);
+
+            secondServiceFromSecondScope = Resolve<TService>(scope2.ServiceProvider, serviceKey);
+        }
+
+        Assert.NotNull(serviceFromFirstScope);
+        Assert.NotNull(serviceFromSecondScope);
+        Assert.NotNull(secondServiceFromSecondScope);
+
+        switch (lifetime)
+        {
+            case ServiceLifetime.Singleton:
+                Assert.Same(serviceFromFirstScope, serviceFromSecondScope);
+                Assert.Same(serviceFromSecondScope, secondServiceFromSecondScope);
+                break;
+            case ServiceLifetime.Scoped:
+                Assert.NotSame(serviceFromFirstScope, serviceFromSecondScope);
+                Assert.Same(serviceFromSecondScope, secondServiceFromSecondScope);
+                break;
+            case ServiceLifetime.Transient:
+                Assert.NotSame(serviceFromFirstScope, serviceFromSecondScope);
+                Assert.NotSame(serviceFromSecondScope, secondServiceFromSecondScope);
+                break;
+        }
+    }
+
+    protected static string CreateConfigKey(string prefix, object? serviceKey, string suffix)
+        => serviceKey is null ? $"{prefix}:{suffix}" : $"{prefix}:{serviceKey}:{suffix}";
+
+    private static TService Resolve<TService>(IServiceProvider serviceProvider, object? serviceKey = null) where TService : notnull
+        => serviceKey is null
+            ? serviceProvider.GetRequiredService<TService>()
+            : serviceProvider.GetRequiredKeyedService<TService>(serviceKey);
+
+    private sealed class FakeVectorStore : VectorStore
+    {
+        public override Task<bool> CollectionExistsAsync(string name, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public override Task EnsureCollectionDeletedAsync(string name, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public override VectorStoreCollection<TKey1, TRecord1> GetCollection<TKey1, TRecord1>(string name, VectorStoreCollectionDefinition? definition = null) => throw new NotImplementedException();
+        public override VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(string name, VectorStoreCollectionDefinition? definition = null) => throw new NotImplementedException();
+        public override object? GetService(Type serviceType, object? serviceKey = null) => throw new NotImplementedException();
+        public override IAsyncEnumerable<string> ListCollectionNamesAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    }
+
+    private sealed class FakeVectorStoreRecordCollection : VectorStoreCollection<TKey, TRecord>
+    {
+        public override string Name => throw new NotImplementedException();
+        public override Task<bool> CollectionExistsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public override Task EnsureCollectionExistsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public override Task DeleteAsync(TKey key, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public override Task EnsureCollectionDeletedAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public override Task<TRecord?> GetAsync(TKey key, RecordRetrievalOptions? options = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public override IAsyncEnumerable<TRecord> GetAsync(Expression<Func<TRecord, bool>> filter, int top, FilteredRecordRetrievalOptions<TRecord>? options = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public override object? GetService(Type serviceType, object? serviceKey = null) => throw new NotImplementedException();
+        public override IAsyncEnumerable<VectorSearchResult<TRecord>> SearchAsync<TInput>(TInput searchValue, int top, VectorSearchOptions<TRecord>? options = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public override Task UpsertAsync(TRecord record, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public override Task UpsertAsync(IEnumerable<TRecord> records, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+    }
+}

--- a/test/VectorData.ConformanceTests/EmbeddingGenerationTests.cs
+++ b/test/VectorData.ConformanceTests/EmbeddingGenerationTests.cs
@@ -1,0 +1,626 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.VectorData;
+using VectorData.ConformanceTests.Support;
+using VectorData.ConformanceTests.Xunit;
+using Xunit;
+
+namespace VectorData.ConformanceTests;
+
+#pragma warning disable CA1819 // Properties should not return arrays
+#pragma warning disable CA2000 // Don't actually need to dispose FakeEmbeddingGenerator
+#pragma warning disable CS8605 // Unboxing a possibly null value.
+
+public abstract class EmbeddingGenerationTests<TKey>(EmbeddingGenerationTests<TKey>.StringVectorFixture stringVectorFixture, EmbeddingGenerationTests<TKey>.RomOfFloatVectorFixture romOfFloatVectorFixture)
+    where TKey : notnull
+{
+    #region Search
+
+    [ConditionalFact]
+    public virtual async Task SearchAsync_with_property_generator()
+    {
+        // Property level: embedding generators are defined at all levels. The property generator should take precedence.
+        var collection = this.GetCollection<Record>(storeGenerator: true, collectionGenerator: true, propertyGenerator: true);
+
+        var result = await collection.SearchAsync("[1, 1, 0]", top: 1).SingleAsync();
+
+        Assert.Equal("Property ([1, 1, 3])", result.Record.Text);
+    }
+
+    [ConditionalFact]
+    public virtual async Task SearchAsync_with_property_generator_dynamic()
+    {
+        // Property level: embedding generators are defined at all levels. The property generator should take precedence.
+        var collection = this.GetDynamicCollection(storeGenerator: true, collectionGenerator: true, propertyGenerator: true);
+
+        var result = await collection.SearchAsync("[1, 1, 0]", top: 1).SingleAsync();
+
+        Assert.Equal("Property ([1, 1, 3])", result.Record[nameof(Record.Text)]);
+    }
+
+    [ConditionalFact]
+    public virtual async Task SearchAsync_with_collection_generator()
+    {
+        // Collection level: embedding generators are defined at the collection and store level - the collection generator should take precedence.
+        var collection = this.GetCollection<Record>(storeGenerator: true, collectionGenerator: true, propertyGenerator: false);
+
+        var result = await collection.SearchAsync("[1, 1, 0]", top: 1).SingleAsync();
+
+        Assert.Equal("Collection ([1, 1, 2])", result.Record.Text);
+    }
+
+    [ConditionalFact]
+    public virtual async Task SearchAsync_with_store_generator()
+    {
+        // Store level: an embedding generator is defined at the store level only.
+        var collection = this.GetCollection<Record>(storeGenerator: true, collectionGenerator: false, propertyGenerator: false);
+
+        var result = await collection.SearchAsync("[1, 1, 0]", top: 1).SingleAsync();
+
+        Assert.Equal("Store ([1, 1, 1])", result.Record.Text);
+    }
+
+    [ConditionalFact]
+    public virtual async Task SearchAsync_with_store_dependency_injection()
+    {
+        foreach (var registrationDelegate in stringVectorFixture.DependencyInjectionStoreRegistrationDelegates)
+        {
+            IServiceCollection serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddSingleton<IEmbeddingGenerator>(new FakeEmbeddingGenerator(replaceLast: 1));
+            registrationDelegate(serviceCollection);
+
+            await using var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            var vectorStore = serviceProvider.GetRequiredService<VectorStore>();
+            var collection = vectorStore.GetCollection<TKey, Record>(stringVectorFixture.CollectionName, stringVectorFixture.CreateRecordDefinition());
+
+            var result = await collection.SearchAsync("[1, 1, 0]", top: 1).SingleAsync();
+
+            Assert.Equal("Store ([1, 1, 1])", result.Record.Text);
+        }
+    }
+
+    [ConditionalFact]
+    public virtual async Task SearchAsync_with_collection_dependency_injection()
+    {
+        foreach (var registrationDelegate in stringVectorFixture.DependencyInjectionCollectionRegistrationDelegates)
+        {
+            IServiceCollection serviceCollection = new ServiceCollection();
+
+            serviceCollection.AddSingleton<IEmbeddingGenerator>(new FakeEmbeddingGenerator(replaceLast: 1));
+            registrationDelegate(serviceCollection);
+
+            await using var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            var collection = serviceProvider.GetRequiredService<VectorStoreCollection<TKey, RecordWithAttributes>>();
+
+            var result = await collection.SearchAsync("[1, 1, 0]", top: 1).SingleAsync();
+
+            Assert.Equal("Store ([1, 1, 1])", result.Record.Text);
+        }
+    }
+
+    [ConditionalFact]
+    public virtual async Task SearchAsync_with_custom_input_type()
+    {
+        var recordDefinition = new VectorStoreCollectionDefinition()
+        {
+            Properties = stringVectorFixture.CreateRecordDefinition().Properties
+                .Select(p => p is VectorStoreVectorProperty vectorProperty
+                    ? new VectorStoreVectorProperty<Customer>(nameof(Record.Embedding), dimensions: 3)
+                    {
+                        DistanceFunction = stringVectorFixture.DefaultDistanceFunction,
+                        IndexKind = stringVectorFixture.DefaultIndexKind
+                    }
+                    : p)
+                .ToList()
+        };
+
+        var collection = stringVectorFixture.GetCollection<RecordWithCustomerVectorProperty>(
+            stringVectorFixture.CreateVectorStore(new FakeCustomerEmbeddingGenerator([1, 1, 1])),
+            stringVectorFixture.CollectionName,
+            recordDefinition);
+
+        var result = await collection.SearchAsync(new Customer(), top: 1).SingleAsync();
+
+        Assert.Equal("Store ([1, 1, 1])", result.Record.Text);
+    }
+
+    [ConditionalFact]
+    public virtual async Task SearchAsync_with_search_only_embedding_generation()
+    {
+        var collection = romOfFloatVectorFixture.GetCollection<RecordWithRomOfFloatVectorProperty>(
+            romOfFloatVectorFixture.CreateVectorStore(new FakeEmbeddingGenerator()),
+            romOfFloatVectorFixture.CollectionName,
+            romOfFloatVectorFixture.CreateRecordDefinition());
+
+        var result = await collection.SearchAsync("[1, 1, 1]", top: 1).SingleAsync();
+
+        Assert.Equal("Store ([1, 1, 1])", result.Record.Text);
+    }
+
+    [ConditionalFact]
+    public virtual async Task SearchAsync_string_without_generator_throws()
+    {
+        // The database doesn't support embedding generation, and no client-side generator has been configured at any level,
+        // so SearchAsync should throw for string.
+        var collection = stringVectorFixture.GetCollection<RawRecord>(stringVectorFixture.TestStore.DefaultVectorStore, stringVectorFixture.CollectionName + "withoutgenerator");
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(() => collection.SearchAsync("foo", top: 1).ToListAsync().AsTask());
+
+        Assert.StartsWith(
+            "A value of type 'string' was passed to 'SearchAsync', but that isn't a supported vector type by your provider and no embedding generator was configured. The supported vector types are:",
+            exception.Message);
+    }
+
+    public class RawRecord
+    {
+        [VectorStoreKey]
+        public TKey Key { get; set; } = default!;
+        [VectorStoreVector(Dimensions: 3)]
+        public ReadOnlyMemory<float> Embedding { get; set; }
+    }
+
+    [ConditionalFact]
+    public virtual async Task SearchAsync_with_incompatible_generator_throws()
+    {
+        var collection = this.GetCollection<Record>(storeGenerator: true, collectionGenerator: true, propertyGenerator: true);
+
+        // We have a generator configured for string, not int.
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => collection.SearchAsync(8, top: 1).ToListAsync().AsTask());
+
+        Assert.Equal($"An input of type 'int' was provided, but an incompatible embedding generator of type '{nameof(FakeEmbeddingGenerator)}' was configured.", exception.Message);
+    }
+
+    #endregion Search
+
+    #region Upsert
+
+    [ConditionalFact]
+    public virtual async Task UpsertAsync()
+    {
+        var counter = stringVectorFixture.GenerateNextCounter();
+
+        var record = new Record
+        {
+            Key = stringVectorFixture.GenerateNextKey<TKey>(),
+            Embedding = "[100, 1, 0]",
+            Counter = counter,
+            Text = nameof(UpsertAsync)
+        };
+
+        // Property level: embedding generators are defined at all levels. The property generator should take precedence.
+        var collection = this.GetCollection<Record>(storeGenerator: true, collectionGenerator: true, propertyGenerator: true);
+
+        await collection.UpsertAsync(record).ConfigureAwait(false);
+
+        await stringVectorFixture.TestStore.WaitForDataAsync(collection, 1, filter: r => r.Counter == counter);
+
+        var result = await collection.SearchAsync(new ReadOnlyMemory<float>([100, 1, 3]), top: 1).SingleAsync();
+        Assert.Equal(counter, result.Record.Counter);
+    }
+
+    [ConditionalFact]
+    public virtual async Task UpsertAsync_dynamic()
+    {
+        var counter = stringVectorFixture.GenerateNextCounter();
+
+        var record = new Dictionary<string, object?>
+        {
+            [nameof(Record.Key)] = stringVectorFixture.GenerateNextKey<TKey>(),
+            [nameof(Record.Embedding)] = "[200, 1, 0]",
+            [nameof(Record.Counter)] = counter,
+            [nameof(Record.Text)] = nameof(UpsertAsync_dynamic)
+        };
+
+        // Property level: embedding generators are defined at all levels. The property generator should take precedence.
+        var collection = this.GetDynamicCollection(storeGenerator: true, collectionGenerator: true, propertyGenerator: true);
+
+        await collection.UpsertAsync(record).ConfigureAwait(false);
+
+        await stringVectorFixture.TestStore.WaitForDataAsync(collection, 1, filter: r => (int)r[nameof(Record.Counter)] == counter);
+
+        var result = await collection.SearchAsync(new ReadOnlyMemory<float>([200, 1, 3]), top: 1).SingleAsync();
+        Assert.Equal(counter, result.Record[nameof(Record.Counter)]);
+    }
+
+    [ConditionalFact]
+    public virtual async Task UpsertAsync_batch()
+    {
+        var (counter1, counter2) = (stringVectorFixture.GenerateNextCounter(), stringVectorFixture.GenerateNextCounter());
+
+        Record[] records =
+        [
+            new()
+            {
+                Key = stringVectorFixture.GenerateNextKey<TKey>(),
+                Embedding = "[300, 1, 0]",
+                Counter = counter1,
+                Text = nameof(UpsertAsync_batch) + "1"
+            },
+            new()
+            {
+                Key = stringVectorFixture.GenerateNextKey<TKey>(),
+                Embedding = "[400, 1, 0]",
+                Counter = counter2,
+                Text = nameof(UpsertAsync_batch) + "2"
+            }
+        ];
+
+        var collection = this.GetCollection<Record>(storeGenerator: true, collectionGenerator: true, propertyGenerator: true);
+
+        await collection.UpsertAsync(records).ConfigureAwait(false);
+
+        await stringVectorFixture.TestStore.WaitForDataAsync(collection, 2, filter: r => (int)r.Counter == counter1 || (int)r.Counter == counter2);
+
+        var result = await collection.SearchAsync(new ReadOnlyMemory<float>([300, 1, 3]), top: 1).SingleAsync();
+        Assert.Equal(counter1, result.Record.Counter);
+
+        result = await collection.SearchAsync(new ReadOnlyMemory<float>([400, 1, 3]), top: 1).SingleAsync();
+        Assert.Equal(counter2, result.Record.Counter);
+    }
+
+    [ConditionalFact]
+    public virtual async Task UpsertAsync_batch_dynamic()
+    {
+        var (counter1, counter2) = (stringVectorFixture.GenerateNextCounter(), stringVectorFixture.GenerateNextCounter());
+
+        Dictionary<string, object?>[] records =
+        [
+            new()
+            {
+                [nameof(Record.Key)] = stringVectorFixture.GenerateNextKey<TKey>(),
+                [nameof(Record.Embedding)] = "[500, 1, 0]",
+                [nameof(Record.Counter)] = counter1,
+                [nameof(Record.Text)] = nameof(UpsertAsync_batch_dynamic) + "1"
+            },
+            new()
+            {
+                [nameof(Record.Key)] = stringVectorFixture.GenerateNextKey<TKey>(),
+                [nameof(Record.Embedding)] = "[600, 1, 0]",
+                [nameof(Record.Counter)] = counter2,
+                [nameof(Record.Text)] = nameof(UpsertAsync_batch_dynamic) + "2"
+            }
+        ];
+
+        var collection = this.GetDynamicCollection(storeGenerator: true, collectionGenerator: true, propertyGenerator: true);
+
+        await collection.UpsertAsync(records).ConfigureAwait(false);
+
+        await stringVectorFixture.TestStore.WaitForDataAsync(collection, 2, filter: r => (int)r[nameof(Record.Counter)] == counter1 || (int)r[nameof(Record.Counter)] == counter2);
+
+        var result = await collection.SearchAsync(new ReadOnlyMemory<float>([500, 1, 3]), top: 1).SingleAsync();
+        Assert.Equal(counter1, result.Record[nameof(Record.Counter)]);
+
+        result = await collection.SearchAsync(new ReadOnlyMemory<float>([600, 1, 3]), top: 1).SingleAsync();
+        Assert.Equal(counter2, result.Record[nameof(Record.Counter)]);
+    }
+
+    #endregion Upsert
+
+    #region IncludeVectors
+
+    [ConditionalFact]
+    public virtual async Task SearchAsync_with_IncludeVectors_throws()
+    {
+        var collection = this.GetCollection<Record>(storeGenerator: true, collectionGenerator: true, propertyGenerator: true);
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(() => collection.SearchAsync("[1, 0, 0]", top: 1, new() { IncludeVectors = true }).ToListAsync().AsTask());
+
+        Assert.Equal("When an embedding generator is configured, `Include Vectors` cannot be enabled.", exception.Message);
+    }
+
+    [ConditionalFact]
+    public virtual async Task GetAsync_with_IncludeVectors_throws()
+    {
+        var collection = this.GetCollection<Record>(storeGenerator: true, collectionGenerator: true, propertyGenerator: true);
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(() => collection.GetAsync(stringVectorFixture.TestData[0].Key, new() { IncludeVectors = true }));
+
+        Assert.Equal("When an embedding generator is configured, `Include Vectors` cannot be enabled.", exception.Message);
+    }
+
+    [ConditionalFact]
+    public virtual async Task GetAsync_enumerable_with_IncludeVectors_throws()
+    {
+        var collection = this.GetCollection<Record>(storeGenerator: true, collectionGenerator: true, propertyGenerator: true);
+
+        var exception = await Assert.ThrowsAsync<NotSupportedException>(() =>
+            collection.GetAsync(
+                [stringVectorFixture.TestData[0].Key, stringVectorFixture.TestData[1].Key],
+                new() { IncludeVectors = true })
+                .ToListAsync().AsTask());
+
+        Assert.Equal("When an embedding generator is configured, `Include Vectors` cannot be enabled.", exception.Message);
+    }
+
+    #endregion IncludeVectors
+
+    #region Support
+
+    public class Record
+    {
+        public TKey Key { get; set; } = default!;
+        public string? Embedding { get; set; }
+
+        public int Counter { get; set; }
+        public string? Text { get; set; }
+    }
+
+    public class RecordWithAttributes
+    {
+        [VectorStoreKey]
+        public TKey Key { get; set; } = default!;
+
+        [VectorStoreVector(Dimensions: 3)]
+        public string? Embedding { get; set; }
+
+        [VectorStoreData(IsIndexed = true)]
+        public int Counter { get; set; }
+
+        [VectorStoreData]
+        public string? Text { get; set; }
+    }
+
+    public class RecordWithCustomerVectorProperty
+    {
+        public TKey Key { get; set; } = default!;
+        public Customer? Embedding { get; set; }
+
+        public int Counter { get; set; }
+        public string? Text { get; set; }
+    }
+
+    public class RecordWithRomOfFloatVectorProperty
+    {
+        public TKey Key { get; set; } = default!;
+        public ReadOnlyMemory<float> Embedding { get; set; }
+
+        public int Counter { get; set; }
+        public string? Text { get; set; }
+    }
+
+    public class Customer
+    {
+        public string? FirstName { get; set; }
+        public string? LastName { get; set; }
+    }
+
+    private VectorStoreCollection<TKey, TRecord> GetCollection<TRecord>(
+        bool storeGenerator = false,
+        bool collectionGenerator = false,
+        bool propertyGenerator = false)
+        where TRecord : class
+    {
+        var (vectorStore, recordDefinition) = this.GetStoreAndRecordDefinition(storeGenerator, collectionGenerator, propertyGenerator);
+
+        return stringVectorFixture.GetCollection<TRecord>(vectorStore, stringVectorFixture.CollectionName, recordDefinition);
+    }
+
+    private VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(
+        bool storeGenerator = false,
+        bool collectionGenerator = false,
+        bool propertyGenerator = false)
+    {
+        var (vectorStore, recordDefinition) = this.GetStoreAndRecordDefinition(storeGenerator, collectionGenerator, propertyGenerator);
+
+        return stringVectorFixture.GetDynamicCollection(vectorStore, stringVectorFixture.CollectionName, recordDefinition);
+    }
+
+    private (VectorStore, VectorStoreCollectionDefinition) GetStoreAndRecordDefinition(
+        bool storeGenerator = false,
+        bool collectionGenerator = false,
+        bool propertyGenerator = false)
+    {
+        var recordDefinition = stringVectorFixture.CreateRecordDefinition();
+
+        if (propertyGenerator)
+        {
+            foreach (var vectorProperty in recordDefinition.Properties.OfType<VectorStoreVectorProperty>())
+            {
+                vectorProperty.EmbeddingGenerator = new FakeEmbeddingGenerator(replaceLast: 3);
+            }
+        }
+
+        if (collectionGenerator)
+        {
+            recordDefinition.EmbeddingGenerator = new FakeEmbeddingGenerator(replaceLast: 2);
+        }
+
+        var vectorStore = stringVectorFixture.CreateVectorStore(storeGenerator ? new FakeEmbeddingGenerator(replaceLast: 1) : null);
+
+        return (vectorStore, recordDefinition);
+    }
+
+    public abstract class StringVectorFixture : VectorStoreCollectionFixture<TKey, Record>
+    {
+        private int _counter;
+
+        public override string CollectionName => "EmbeddingGenerationTests";
+
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
+            => new()
+            {
+                Properties =
+                [
+                    new VectorStoreKeyProperty(nameof(Record.Key), typeof(TKey)),
+                    new VectorStoreVectorProperty(nameof(Record.Embedding), typeof(string), dimensions: 3)
+                    {
+                        DistanceFunction = this.DefaultDistanceFunction,
+                        IndexKind = this.DefaultIndexKind
+                    },
+
+                    new VectorStoreDataProperty(nameof(Record.Counter), typeof(int)) { IsIndexed = true },
+                    new VectorStoreDataProperty(nameof(Record.Text), typeof(string))
+                ],
+                EmbeddingGenerator = new FakeEmbeddingGenerator()
+            };
+
+        protected override List<Record> BuildTestData() =>
+        [
+            new()
+            {
+                Key = this.GenerateNextKey<TKey>(),
+                Embedding = "[1, 1, 1]",
+                Counter = this.GenerateNextCounter(),
+                Text = "Store ([1, 1, 1])"
+            },
+            new()
+            {
+                Key = this.GenerateNextKey<TKey>(),
+                Embedding = "[1, 1, 2]",
+                Counter = this.GenerateNextCounter(),
+                Text = "Collection ([1, 1, 2])"
+            },
+            new()
+            {
+                Key = this.GenerateNextKey<TKey>(),
+                Embedding = "[1, 1, 3]",
+                Counter = this.GenerateNextCounter(),
+                Text = "Property ([1, 1, 3])"
+            }
+        ];
+
+        public virtual VectorStoreCollection<TKey, TRecord> GetCollection<TRecord>(
+            VectorStore vectorStore,
+            string collectionName,
+            VectorStoreCollectionDefinition? recordDefinition = null)
+            where TRecord : class
+            => vectorStore.GetCollection<TKey, TRecord>(collectionName, recordDefinition);
+
+        public virtual VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(
+            VectorStore vectorStore,
+            string collectionName,
+            VectorStoreCollectionDefinition recordDefinition)
+            => vectorStore.GetDynamicCollection(collectionName, recordDefinition);
+
+        public abstract VectorStore CreateVectorStore(IEmbeddingGenerator? embeddingGenerator = null);
+
+        public abstract Func<IServiceCollection, IServiceCollection>[] DependencyInjectionStoreRegistrationDelegates { get; }
+        public abstract Func<IServiceCollection, IServiceCollection>[] DependencyInjectionCollectionRegistrationDelegates { get; }
+
+        public virtual int GenerateNextCounter()
+            => Interlocked.Increment(ref this._counter);
+    }
+
+    public abstract class RomOfFloatVectorFixture : VectorStoreCollectionFixture<TKey, RecordWithRomOfFloatVectorProperty>
+    {
+        private int _counter;
+
+        public override string CollectionName => "SearchOnlyEmbeddingGenerationTests";
+
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
+            => new()
+            {
+                Properties =
+                [
+                    new VectorStoreKeyProperty(nameof(RecordWithRomOfFloatVectorProperty.Key), typeof(TKey)),
+                    new VectorStoreVectorProperty(nameof(RecordWithRomOfFloatVectorProperty.Embedding), typeof(ReadOnlyMemory<float>), dimensions: 3)
+                    {
+                        DistanceFunction = this.DefaultDistanceFunction,
+                        IndexKind = this.DefaultIndexKind
+                    },
+
+                    new VectorStoreDataProperty(nameof(RecordWithRomOfFloatVectorProperty.Counter), typeof(int)) { IsIndexed = true },
+                    new VectorStoreDataProperty(nameof(RecordWithRomOfFloatVectorProperty.Text), typeof(string))
+                ],
+                EmbeddingGenerator = new FakeEmbeddingGenerator()
+            };
+
+        protected override List<RecordWithRomOfFloatVectorProperty> BuildTestData() =>
+        [
+            new()
+            {
+                Key = this.GenerateNextKey<TKey>(),
+                Embedding = new ReadOnlyMemory<float>([1, 1, 1]),
+                Counter = this.GenerateNextCounter(),
+                Text = "Store ([1, 1, 1])",
+            },
+            new()
+            {
+                Key = this.GenerateNextKey<TKey>(),
+                Embedding = new ReadOnlyMemory<float>([1, 1, 2]),
+                Counter = this.GenerateNextCounter(),
+                Text = "Collection ([1, 1, 2])"
+            },
+            new()
+            {
+                Key = this.GenerateNextKey<TKey>(),
+                Embedding = new ReadOnlyMemory<float>([1, 1, 3]),
+                Counter = this.GenerateNextCounter(),
+                Text = "Property ([1, 1, 3])"
+            }
+        ];
+
+        public virtual VectorStoreCollection<TKey, TRecord> GetCollection<TRecord>(
+            VectorStore vectorStore,
+            string collectionName,
+            VectorStoreCollectionDefinition? recordDefinition = null)
+            where TRecord : class
+            => vectorStore.GetCollection<TKey, TRecord>(collectionName, recordDefinition);
+
+        public virtual VectorStoreCollection<object, Dictionary<string, object?>> GetDynamicCollection(
+            VectorStore vectorStore,
+            string collectionName,
+            VectorStoreCollectionDefinition recordDefinition)
+            => vectorStore.GetDynamicCollection(collectionName, recordDefinition);
+
+        public abstract VectorStore CreateVectorStore(IEmbeddingGenerator? embeddingGenerator = null);
+
+        public abstract Func<IServiceCollection, IServiceCollection>[] DependencyInjectionStoreRegistrationDelegates { get; }
+        public abstract Func<IServiceCollection, IServiceCollection>[] DependencyInjectionCollectionRegistrationDelegates { get; }
+
+        public virtual int GenerateNextCounter()
+            => Interlocked.Increment(ref this._counter);
+    }
+
+    private sealed class FakeEmbeddingGenerator(int? replaceLast = null) : IEmbeddingGenerator<string, Embedding<float>>
+    {
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(
+            IEnumerable<string> values,
+            EmbeddingGenerationOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var results = new GeneratedEmbeddings<Embedding<float>>();
+
+            foreach (var value in values)
+            {
+                var vector = value.TrimStart('[').TrimEnd(']').Split(',').Select(s => float.Parse(s.Trim())).ToArray();
+
+                if (replaceLast is not null)
+                {
+                    vector[vector.Length - 1] = replaceLast.Value;
+                }
+
+                results.Add(new Embedding<float>(vector));
+            }
+
+            return Task.FromResult(results);
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class FakeCustomerEmbeddingGenerator(float[] embedding) : IEmbeddingGenerator<Customer, Embedding<float>>
+    {
+        public Task<GeneratedEmbeddings<Embedding<float>>> GenerateAsync(IEnumerable<Customer> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new GeneratedEmbeddings<Embedding<float>> { new(embedding) });
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => null;
+
+        public void Dispose()
+        {
+        }
+    }
+
+    #endregion Support
+}

--- a/test/VectorData.ConformanceTests/EmbeddingTypeTests.cs
+++ b/test/VectorData.ConformanceTests/EmbeddingTypeTests.cs
@@ -1,0 +1,230 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.VectorData;
+using VectorData.ConformanceTests.Support;
+using VectorData.ConformanceTests.Xunit;
+using Xunit;
+
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+namespace VectorData.ConformanceTests;
+
+/// <summary>
+/// Tests that the various embedding types natively supported by the provider (<c>ReadOnlyMemory&lt;float&gt;</c>, <c>ReadOnlyMemory&lt;Half&gt;</c>...) work correctly.
+/// </summary>
+public abstract class EmbeddingTypeTests<TKey>(EmbeddingTypeTests<TKey>.Fixture fixture)
+    where TKey : notnull
+{
+    [ConditionalFact]
+    public virtual Task ReadOnlyMemory_of_float()
+        => this.Test<ReadOnlyMemory<float>>(
+            new ReadOnlyMemory<float>([1, 2, 3]),
+            new ReadOnlyMemoryEmbeddingGenerator<float>([1, 2, 3]),
+            vectorEqualityAsserter: (e, a) => Assert.Equal(e.Span.ToArray(), a.Span.ToArray()));
+
+    [ConditionalFact]
+    public virtual Task Embedding_of_float()
+        => this.Test<Embedding<float>>(
+            new Embedding<float>(new ReadOnlyMemory<float>([1, 2, 3])),
+            new ReadOnlyMemoryEmbeddingGenerator<float>([1, 2, 3]),
+            vectorEqualityAsserter: (e, a) => Assert.Equal(e.Vector.Span.ToArray(), a.Vector.Span.ToArray()));
+
+    [ConditionalFact]
+    public virtual Task Array_of_float()
+        => this.Test<float[]>(
+            [1, 2, 3],
+            new ReadOnlyMemoryEmbeddingGenerator<float>([1, 2, 3]));
+
+    protected virtual async Task Test<TVector>(TVector value, IEmbeddingGenerator? embeddingGenerator = null, Action<TVector, TVector>? vectorEqualityAsserter = null, string? distanceFunction = null, int dimensions = 3)
+        where TVector : notnull
+    {
+        vectorEqualityAsserter ??= (e, a) => Assert.Equal(e, a);
+
+        await fixture.VectorStore.EnsureCollectionDeletedAsync(fixture.CollectionName);
+
+        var collection = fixture.VectorStore.GetCollection<TKey, Record<TVector>>(fixture.CollectionName, fixture.CreateRecordDefinition<TVector>(embeddingGenerator: null, distanceFunction, dimensions));
+        await collection.EnsureCollectionExistsAsync();
+
+        var key = fixture.GenerateNextKey<TKey>();
+        var record = new Record<TVector>
+        {
+            Key = key,
+            Vector = value,
+            Int = 42
+        };
+
+        await collection.UpsertAsync(record);
+
+        await fixture.TestStore.WaitForDataAsync(collection, recordCount: 1, filter: r => r.Int == 42, dummyVector: value);
+
+        var result1 = await collection.GetAsync(key, new() { IncludeVectors = true });
+        Assert.Equal(42, result1!.Int);
+        if (fixture.TestStore.VectorsComparable)
+        {
+            vectorEqualityAsserter(value, result1.Vector);
+        }
+
+        // Note that some databases leak indexing information across deletion/recreation of the same collection name (e.g. Pinecone) - so we also
+        // filter by Int here.
+        var result2 = await collection.SearchAsync(value, top: 1, new() { IncludeVectors = true, Filter = r => r.Int == 42 }).SingleAsync();
+        Assert.Equal(42, result2.Record.Int);
+        if (fixture.TestStore.VectorsComparable)
+        {
+            vectorEqualityAsserter(value, result2.Record.Vector);
+        }
+
+        ///////////////////////
+        // Test dynamic mapping
+        ///////////////////////
+        if (fixture.RecreateCollection)
+        {
+            await collection.EnsureCollectionDeletedAsync();
+        }
+        else
+        {
+            await collection.DeleteAsync(key);
+        }
+
+        var dynamicCollection = fixture.VectorStore.GetDynamicCollection(fixture.CollectionName, fixture.CreateRecordDefinition<TVector>(embeddingGenerator, distanceFunction, dimensions));
+
+        if (fixture.RecreateCollection)
+        {
+            await dynamicCollection.EnsureCollectionExistsAsync();
+        }
+
+        key = fixture.GenerateNextKey<TKey>();
+        var dynamicRecord = new Dictionary<string, object?>
+        {
+            ["Key"] = key,
+            ["Vector"] = value,
+            ["Int"] = 43
+        };
+
+        await dynamicCollection.UpsertAsync(dynamicRecord);
+
+        await fixture.TestStore.WaitForDataAsync(dynamicCollection, recordCount: 1, filter: r => (int)r["Int"]! == 43, dummyVector: value);
+
+        var dynamicResult1 = await dynamicCollection.GetAsync(key, new() { IncludeVectors = true });
+        Assert.Equal(43, dynamicResult1!["Int"]);
+        if (fixture.TestStore.VectorsComparable)
+        {
+            vectorEqualityAsserter(value, (TVector)dynamicResult1["Vector"]!);
+        }
+
+        // Note that some databases leak indexing information across deletion/recreation of the same collection name (e.g. Pinecone) - so we also
+        // filter by Int here.
+        var dynamicResult2 = await dynamicCollection.SearchAsync(value, top: 1, new() { IncludeVectors = true, Filter = r => (int)r["Int"]! == 43 }).SingleAsync();
+        Assert.Equal(43, dynamicResult2.Record["Int"]);
+        if (fixture.TestStore.VectorsComparable)
+        {
+            vectorEqualityAsserter(value, (TVector)dynamicResult2.Record["Vector"]!);
+        }
+
+        ////////////////////////////
+        // Test embedding generation
+        ////////////////////////////
+        if (embeddingGenerator is not null)
+        {
+            if (fixture.RecreateCollection)
+            {
+                await collection.EnsureCollectionDeletedAsync();
+            }
+            else
+            {
+                await collection.DeleteAsync(key);
+            }
+
+            var collection2 = fixture.VectorStore.GetCollection<TKey, RecordWithString>(fixture.CollectionName, fixture.CreateRecordDefinition<string>(embeddingGenerator, distanceFunction, dimensions));
+
+            if (fixture.RecreateCollection)
+            {
+                await collection2.EnsureCollectionExistsAsync();
+            }
+
+            var key2 = fixture.GenerateNextKey<TKey>();
+            var record2 = new RecordWithString
+            {
+                Key = key,
+                Vector = "does not matter",
+                Int = 44
+            };
+
+            await collection2.UpsertAsync(record2);
+
+            await fixture.TestStore.WaitForDataAsync(collection2, recordCount: 1, filter: r => r.Int == 44, dummyVector: value);
+
+            var result3 = await collection2.GetAsync(key);
+            Assert.Equal(44, result3!.Int);
+            if (fixture.AssertNoVectorsLoadedWithEmbeddingGeneration)
+            {
+                Assert.Null(result3.Vector);
+            }
+
+            var result4 = await collection2.SearchAsync("does not matter", top: 1, new() { Filter = r => r.Int == 44 }).SingleAsync();
+            Assert.Equal(44, result4.Record.Int);
+            if (fixture.AssertNoVectorsLoadedWithEmbeddingGeneration)
+            {
+                Assert.Null(result4.Record.Vector);
+            }
+        }
+    }
+
+    protected sealed class ReadOnlyMemoryEmbeddingGenerator<T>(T[] data) : IEmbeddingGenerator<string, Embedding<T>>
+    {
+        public Task<GeneratedEmbeddings<Embedding<T>>> GenerateAsync(IEnumerable<string> values, EmbeddingGenerationOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(new GeneratedEmbeddings<Embedding<T>>([new(data)]));
+
+        public object? GetService(Type serviceType, object? serviceKey = null) => null;
+        public void Dispose() { }
+    }
+
+    public class RecordWithString
+    {
+        public TKey Key { get; set; }
+        public string Vector { get; set; }
+        public int Int { get; set; }
+    }
+
+    public class Record<TVector>
+    {
+        public TKey Key { get; set; }
+        public TVector Vector { get; set; }
+        public int Int { get; set; }
+    }
+
+    public abstract class Fixture : VectorStoreFixture
+    {
+        public virtual string CollectionName => "EmbeddingTypeTests";
+
+        public virtual VectorStoreCollectionDefinition CreateRecordDefinition<TVectorProperty>(IEmbeddingGenerator? embeddingGenerator, string? distanceFunction, int dimensions)
+            => new()
+            {
+                Properties =
+                [
+                    new VectorStoreKeyProperty("Key", typeof(TKey)),
+                    new VectorStoreVectorProperty("Vector", typeof(TVectorProperty), dimensions)
+                    {
+                        DistanceFunction = distanceFunction ?? this.DefaultDistanceFunction,
+                        IndexKind = this.DefaultIndexKind
+                    },
+                    new VectorStoreDataProperty("Int", typeof(int)) { IsIndexed = true }
+                ],
+                EmbeddingGenerator = embeddingGenerator
+            };
+
+        /// <summary>
+        /// Whether the recreate the collection while testing, as opposed to deleting the records.
+        /// Necessary for InMemory, where the .NET mapped on the collection cannot be changed.
+        /// </summary>
+        public virtual bool RecreateCollection => false;
+
+        /// <summary>
+        /// Whether to assert that no vectors were loaded when embedding generation is used.
+        /// Necessary for InMemory which returns the same object which was inserted, and therefore contains
+        /// the original input value.
+        /// </summary>
+        public virtual bool AssertNoVectorsLoadedWithEmbeddingGeneration => true;
+    }
+}

--- a/test/VectorData.ConformanceTests/Filter/BasicFilterTests.cs
+++ b/test/VectorData.ConformanceTests/Filter/BasicFilterTests.cs
@@ -1,0 +1,722 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq.Expressions;
+using Microsoft.Extensions.VectorData;
+using VectorData.ConformanceTests.Support;
+using VectorData.ConformanceTests.Xunit;
+using Xunit;
+
+#pragma warning disable CS8605 // Unboxing a possibly null value.
+#pragma warning disable CS0252 // Possible unintended reference comparison; left hand side needs cast
+#pragma warning disable RCS1098 // Constant values should be placed on right side of comparisons
+
+namespace VectorData.ConformanceTests.Filter;
+
+public abstract class BasicFilterTests<TKey>(BasicFilterTests<TKey>.Fixture fixture)
+    where TKey : notnull
+{
+    #region Equality
+
+    [ConditionalFact]
+    public virtual Task Equal_with_int()
+        => this.TestFilterAsync(
+            r => r.Int == 8,
+            r => (int)r["Int"] == 8);
+
+    [ConditionalFact]
+    public virtual Task Equal_with_string()
+        => this.TestFilterAsync(
+            r => r.String == "foo",
+            r => r["String"] == "foo");
+
+    [ConditionalFact]
+    public virtual Task Equal_with_string_sql_injection_in_value()
+    {
+        string sqlInjection = $"foo; DROP TABLE {fixture.Collection.Name};";
+
+        return this.TestFilterAsync(
+            r => r.String == sqlInjection,
+            r => r["String"] == sqlInjection,
+            expectZeroResults: true);
+    }
+
+    [ConditionalFact]
+    public virtual async Task Equal_with_string_sql_injection_in_name()
+    {
+        if (fixture.TestDynamic)
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => this.GetDynamicRecords(r => r["String = \"not\"; DROP TABLE FilterTests;"] == "",
+            fixture.TestData.Count, new ReadOnlyMemory<float>([1, 2, 3])));
+        }
+    }
+
+    [ConditionalFact]
+    public virtual Task Equal_with_string_containing_special_characters()
+        => this.TestFilterAsync(
+            r => r.String == fixture.SpecialCharactersText,
+            r => r["String"] == fixture.SpecialCharactersText);
+
+    [ConditionalFact]
+    public virtual Task Equal_with_string_is_not_Contains()
+        => this.TestFilterAsync(
+            r => r.String == "some",
+            r => r["String"] == "some",
+            expectZeroResults: true);
+
+    [ConditionalFact]
+    public virtual Task Equal_reversed()
+        => this.TestFilterAsync(
+            r => 8 == r.Int,
+            r => 8 == (int)r["Int"]);
+
+    [ConditionalFact]
+    public virtual Task Equal_with_null_reference_type()
+        => this.TestFilterAsync(
+            r => r.String == null,
+            r => r["String"] == null);
+
+    [ConditionalFact]
+    public virtual Task Equal_with_null_captured()
+    {
+        string? s = null;
+
+        return this.TestFilterAsync(
+            r => r.String == s,
+            r => r["String"] == s);
+    }
+
+    [ConditionalFact]
+    public virtual Task Equal_int_property_with_nonnull_nullable_int()
+    {
+        int? i = 8;
+
+        return this.TestFilterAsync(
+            r => r.Int == i,
+            r => (int)r["Int"] == i);
+    }
+
+    [ConditionalFact]
+    public virtual Task Equal_int_property_with_null_nullable_int()
+    {
+        int? i = null;
+
+        return this.TestFilterAsync(
+            r => r.Int == i,
+            r => (int)r["Int"] == i,
+            expectZeroResults: true);
+    }
+
+    [ConditionalFact]
+    public virtual Task Equal_int_property_with_nonnull_nullable_int_Value()
+    {
+        int? i = 8;
+
+        return this.TestFilterAsync(
+            r => r.Int == i.Value,
+            r => (int)r["Int"] == i.Value);
+    }
+
+#pragma warning disable CS8629 // Nullable value type may be null.
+    [ConditionalFact]
+    public virtual async Task Equal_int_property_with_null_nullable_int_Value()
+    {
+        int? i = null;
+
+        // TODO: Some connectors wrap filter translation exceptions in a VectorStoreException (#11766)
+        var exception = await Assert.ThrowsAnyAsync<Exception>(() => this.TestFilterAsync(
+            r => r.Int == i.Value,
+            r => (int)r["Int"] == i.Value,
+            expectZeroResults: true));
+
+        if (exception is not InvalidOperationException and not VectorStoreException { InnerException: InvalidOperationException })
+        {
+            Assert.Fail($"Expected {nameof(InvalidOperationException)} or {nameof(VectorStoreException)} but got {exception.GetType()}");
+        }
+    }
+#pragma warning restore CS8629
+
+    [ConditionalFact]
+    public virtual Task NotEqual_with_int()
+        => this.TestFilterAsync(
+            r => r.Int != 8,
+            r => (int)r["Int"] != 8);
+
+    [ConditionalFact]
+    public virtual Task NotEqual_with_string()
+        => this.TestFilterAsync(
+            r => r.String != "foo",
+            r => r["String"] != "foo");
+
+    [ConditionalFact]
+    public virtual Task NotEqual_reversed()
+        => this.TestFilterAsync(
+            r => r.Int != 8,
+            r => (int)r["Int"] != 8);
+
+    [ConditionalFact]
+    public virtual Task NotEqual_with_null_reference_type()
+        => this.TestFilterAsync(
+            r => r.String != null,
+            r => r["String"] != null);
+
+    [ConditionalFact]
+    public virtual Task NotEqual_with_null_captured()
+    {
+        string? s = null;
+
+        return this.TestFilterAsync(
+            r => r.String != s,
+            r => r["String"] != s);
+    }
+
+    [ConditionalFact]
+    public virtual Task Bool()
+        => this.TestFilterAsync(
+            r => r.Bool,
+            r => (bool)r["Bool"]);
+
+    [ConditionalFact]
+    public virtual Task Bool_And_Bool()
+        => this.TestFilterAsync(
+            r => r.Bool && r.Bool,
+            r => (bool)r["Bool"] && (bool)r["Bool"]);
+
+    [ConditionalFact]
+    public virtual Task Bool_Or_Not_Bool()
+        => this.TestFilterAsync(
+            r => r.Bool || !r.Bool,
+            r => (bool)r["Bool"] || !(bool)r["Bool"],
+            expectAllResults: true);
+
+    #endregion Equality
+
+    #region Comparison
+
+    [ConditionalFact]
+    public virtual Task GreaterThan_with_int()
+        => this.TestFilterAsync(
+            r => r.Int > 9,
+            r => (int)r["Int"] > 9);
+
+    [ConditionalFact]
+    public virtual Task GreaterThanOrEqual_with_int()
+        => this.TestFilterAsync(
+            r => r.Int >= 9,
+            r => (int)r["Int"] >= 9);
+
+    [ConditionalFact]
+    public virtual Task LessThan_with_int()
+        => this.TestFilterAsync(
+            r => r.Int < 10,
+            r => (int)r["Int"] < 10);
+
+    [ConditionalFact]
+    public virtual Task LessThanOrEqual_with_int()
+        => this.TestFilterAsync(
+            r => r.Int <= 10,
+            r => (int)r["Int"] <= 10);
+
+    #endregion Comparison
+
+    #region Logical operators
+
+    [ConditionalFact]
+    public virtual Task And()
+        => this.TestFilterAsync(
+            r => r.Int == 8 && r.String == "foo",
+            r => (int)r["Int"] == 8 && r["String"] == "foo");
+
+    [ConditionalFact]
+    public virtual Task Or()
+        => this.TestFilterAsync(
+            r => r.Int == 8 || r.String == "foo",
+            r => (int)r["Int"] == 8 || r["String"] == "foo");
+
+    [ConditionalFact]
+    public virtual Task And_within_And()
+        => this.TestFilterAsync(
+            r => (r.Int == 8 && r.String == "foo") && r.Int2 == 80,
+            r => ((int)r["Int"] == 8 && r["String"] == "foo") && (int)r["Int2"] == 80);
+
+    [ConditionalFact]
+    public virtual Task And_within_Or()
+        => this.TestFilterAsync(
+            r => (r.Int == 8 && r.String == "foo") || r.Int2 == 100,
+            r => ((int)r["Int"] == 8 && r["String"] == "foo") || (int)r["Int2"] == 100);
+
+    [ConditionalFact]
+    public virtual Task Or_within_And()
+        => this.TestFilterAsync(
+            r => (r.Int == 8 || r.Int == 9) && r.String == "foo",
+            r => ((int)r["Int"] == 8 || (int)r["Int"] == 9) && r["String"] == "foo");
+
+    [ConditionalFact]
+    public virtual Task Not_over_Equal()
+        // ReSharper disable once NegativeEqualityExpression
+        => this.TestFilterAsync(
+            r => !(r.Int == 8),
+            r => !((int)r["Int"] == 8));
+
+    [ConditionalFact]
+    public virtual Task Not_over_NotEqual()
+        // ReSharper disable once NegativeEqualityExpression
+        => this.TestFilterAsync(
+            r => !(r.Int != 8),
+            r => !((int)r["Int"] != 8));
+
+    [ConditionalFact]
+    public virtual Task Not_over_And()
+        => this.TestFilterAsync(
+            r => !(r.Int == 8 && r.String == "foo"),
+            r => !((int)r["Int"] == 8 && r["String"] == "foo"));
+
+    [ConditionalFact]
+    public virtual Task Not_over_Or()
+        => this.TestFilterAsync(
+            r => !(r.Int == 8 || r.String == "foo"),
+            r => !((int)r["Int"] == 8 || r["String"] == "foo"));
+
+    [ConditionalFact]
+    public virtual Task Not_over_bool()
+        => this.TestFilterAsync(
+            r => !r.Bool,
+            r => !(bool)r["Bool"]);
+
+    [ConditionalFact]
+    public virtual Task Not_over_bool_And_Comparison()
+        => this.TestFilterAsync(
+            r => !r.Bool && r.Int != int.MaxValue,
+            r => !(bool)r["Bool"] && (int)r["Int"] != int.MaxValue);
+
+    #endregion Logical operators
+
+    #region Contains
+
+    [ConditionalFact]
+    public virtual Task Contains_over_field_string_array()
+        => this.TestFilterAsync(
+            r => r.StringArray.Contains("x"),
+            r => ((string[])r["StringArray"]!).Contains("x"));
+
+    [ConditionalFact]
+    public virtual Task Contains_over_field_string_List()
+        => this.TestFilterAsync(
+            r => r.StringList.Contains("x"),
+            r => ((List<string>)r["StringList"]!).Contains("x"));
+
+    [ConditionalFact]
+    public virtual Task Contains_over_inline_int_array()
+        => this.TestFilterAsync(
+            r => new[] { 8, 10 }.Contains(r.Int),
+            r => new[] { 8, 10 }.Contains((int)r["Int"]));
+
+    [ConditionalFact]
+    public virtual Task Contains_over_inline_string_array()
+        => this.TestFilterAsync(
+            r => new[] { "foo", "baz", "unknown" }.Contains(r.String),
+            r => new[] { "foo", "baz", "unknown" }.Contains(r["String"]));
+
+    [ConditionalFact]
+    public virtual Task Contains_over_inline_string_array_with_weird_chars()
+        => this.TestFilterAsync(
+            r => new[] { "foo", "baz", "un  , ' \"" }.Contains(r.String),
+            r => new[] { "foo", "baz", "un  , ' \"" }.Contains(r["String"]));
+
+    [ConditionalFact]
+    public virtual Task Contains_over_captured_string_array()
+    {
+        var array = new[] { "foo", "baz", "unknown" };
+
+        return this.TestFilterAsync(
+            r => array.Contains(r.String),
+            r => array.Contains(r["String"]));
+    }
+
+    #endregion Contains
+
+    #region Variable types
+
+    [ConditionalFact]
+    public virtual Task Captured_local_variable()
+    {
+        // ReSharper disable once ConvertToConstant.Local
+        var i = 8;
+
+        return this.TestFilterAsync(
+            r => r.Int == i,
+            r => (int)r["Int"] == i);
+    }
+
+    [ConditionalFact]
+    public virtual Task Member_field()
+        => this.TestFilterAsync(
+            r => r.Int == this._memberField,
+            r => (int)r["Int"] == this._memberField);
+
+    [ConditionalFact]
+    public virtual Task Member_readonly_field()
+        => this.TestFilterAsync(
+            r => r.Int == this._memberReadOnlyField,
+            r => (int)r["Int"] == this._memberReadOnlyField);
+
+    [ConditionalFact]
+    public virtual Task Member_static_field()
+        => this.TestFilterAsync(
+            r => r.Int == _staticMemberField,
+            r => (int)r["Int"] == _staticMemberField);
+
+    [ConditionalFact]
+    public virtual Task Member_static_readonly_field()
+        => this.TestFilterAsync(
+            r => r.Int == _staticMemberReadOnlyField,
+            r => (int)r["Int"] == _staticMemberReadOnlyField);
+
+    [ConditionalFact]
+    public virtual Task Member_nested_access()
+        => this.TestFilterAsync(
+            r => r.Int == this._someWrapper.SomeWrappedValue,
+            r => (int)r["Int"] == this._someWrapper.SomeWrappedValue);
+
+#pragma warning disable RCS1169 // Make field read-only
+#pragma warning disable IDE0044 // Make field read-only
+#pragma warning disable RCS1187 // Use constant instead of field
+#pragma warning disable CA1802 // Use literals where appropriate
+    private int _memberField = 8;
+    private readonly int _memberReadOnlyField = 8;
+
+    private static int _staticMemberField = 8;
+    private static readonly int _staticMemberReadOnlyField = 8;
+
+    private SomeWrapper _someWrapper = new();
+#pragma warning restore CA1802
+#pragma warning restore RCS1187
+#pragma warning restore RCS1169
+#pragma warning restore IDE0044
+
+    private sealed class SomeWrapper
+    {
+        public int SomeWrappedValue = 8;
+    }
+
+    #endregion Variable types
+
+    #region Legacy filter support
+
+    [ConditionalFact]
+    [Obsolete("Legacy filter support")]
+    public virtual Task Legacy_equality()
+        => this.TestLegacyFilterAsync(
+            new VectorSearchFilter().EqualTo("Int", 8),
+            r => r.Int == 8);
+
+    [ConditionalFact]
+    [Obsolete("Legacy filter support")]
+    public virtual Task Legacy_And()
+        => this.TestLegacyFilterAsync(
+            new VectorSearchFilter().EqualTo("Int", 8).EqualTo("String", "foo"),
+            r => r.Int == 8);
+
+    [ConditionalFact]
+    [Obsolete("Legacy filter support")]
+    public virtual Task Legacy_AnyTagEqualTo_array()
+        => this.TestLegacyFilterAsync(
+            new VectorSearchFilter().AnyTagEqualTo("StringArray", "x"),
+            r => r.StringArray.Contains("x"));
+
+    [ConditionalFact]
+    [Obsolete("Legacy filter support")]
+    public virtual Task Legacy_AnyTagEqualTo_List()
+        => this.TestLegacyFilterAsync(
+            new VectorSearchFilter().AnyTagEqualTo("StringList", "x"),
+            r => r.StringArray.Contains("x"));
+
+    #endregion Legacy filter support
+
+    protected virtual async Task<List<FilterRecord>> GetRecords(
+        Expression<Func<FilterRecord, bool>> filter, int top, ReadOnlyMemory<float> vector)
+        => await fixture.Collection.SearchAsync(
+                vector,
+                top: top,
+                new() { Filter = filter })
+            .Select(r => r.Record).OrderBy(r => r.Key).ToListAsync();
+
+    protected virtual async Task<List<Dictionary<string, object?>>> GetDynamicRecords(
+        Expression<Func<Dictionary<string, object?>, bool>> dynamicFilter, int top, ReadOnlyMemory<float> vector)
+        => await fixture.DynamicCollection.SearchAsync(
+                vector,
+                top: top,
+                new() { Filter = dynamicFilter })
+            .Select(r => r.Record).OrderBy(r => r[nameof(FilterRecord.Key)]).ToListAsync();
+
+    protected virtual async Task TestFilterAsync(
+        Expression<Func<FilterRecord, bool>> filter,
+        Expression<Func<Dictionary<string, object?>, bool>> dynamicFilter,
+        bool expectZeroResults = false,
+        bool expectAllResults = false)
+    {
+        var expected = fixture.TestData.AsQueryable().Where(filter).OrderBy(r => r.Key).ToList();
+
+        if (expected.Count == 0 && !expectZeroResults)
+        {
+            Assert.Fail("The test returns zero results, and so may be unreliable");
+        }
+        else if (expectZeroResults && expected.Count != 0)
+        {
+            Assert.Fail($"{nameof(expectZeroResults)} was true, but the test returned {expected.Count} results.");
+        }
+
+        if (expected.Count == fixture.TestData.Count && !expectAllResults)
+        {
+            Assert.Fail("The test returns all results, and so may be unreliable");
+        }
+        else if (expectAllResults && expected.Count != fixture.TestData.Count)
+        {
+            Assert.Fail($"{nameof(expectAllResults)} was true, but the test returned {expected.Count} results instead of the expected {fixture.TestData.Count}.");
+        }
+
+        // Execute the query against the vector store, once using the strongly typed filter
+        // and once using the dynamic filter
+        var actual = await this.GetRecords(filter, fixture.TestData.Count, new ReadOnlyMemory<float>([1, 2, 3]));
+
+        if (actual.Count != expected.Count)
+        {
+            Assert.Fail($"Expected {expected.Count} results, but got {actual.Count}");
+        }
+
+        foreach (var (e, a) in expected.Zip(actual, (e, a) => (e, a)))
+        {
+            fixture.AssertEqualFilterRecord(e, a);
+        }
+
+        if (fixture.TestDynamic)
+        {
+            var dynamicActual = await this.GetDynamicRecords(dynamicFilter, fixture.TestData.Count, new ReadOnlyMemory<float>([1, 2, 3]));
+
+            if (dynamicActual.Count != expected.Count)
+            {
+                Assert.Fail($"Expected {expected.Count} results, but got {actual.Count}");
+            }
+
+            foreach (var (e, a) in expected.Zip(dynamicActual, (e, a) => (e, a)))
+            {
+                fixture.AssertEqualDynamic(e, a);
+            }
+        }
+    }
+
+    [Obsolete("Legacy filter support")]
+    protected virtual async Task TestLegacyFilterAsync(
+        VectorSearchFilter legacyFilter,
+        Expression<Func<FilterRecord, bool>> expectedFilter,
+        bool expectZeroResults = false,
+        bool expectAllResults = false)
+    {
+        var expected = fixture.TestData.AsQueryable().Where(expectedFilter).OrderBy(r => r.Key).ToList();
+
+        if (expected.Count == 0 && !expectZeroResults)
+        {
+            Assert.Fail("The test returns zero results, and so is unreliable");
+        }
+
+        if (expected.Count == fixture.TestData.Count && !expectAllResults)
+        {
+            Assert.Fail("The test returns all results, and so is unreliable");
+        }
+
+        var actual = await fixture.Collection.SearchAsync(
+                new ReadOnlyMemory<float>([1, 2, 3]),
+                top: fixture.TestData.Count,
+                new()
+                {
+                    OldFilter = legacyFilter
+                })
+            .Select(r => r.Record).OrderBy(r => r.Key).ToListAsync();
+
+        foreach (var (e, a) in expected.Zip(actual, (e, a) => (e, a)))
+        {
+            fixture.AssertEqualFilterRecord(e, a);
+        }
+    }
+
+#pragma warning disable CS1819 // Properties should not return arrays
+#pragma warning disable CA1819 // Properties should not return arrays
+    public class FilterRecord
+    {
+        public TKey Key { get; set; } = default!;
+        public ReadOnlyMemory<float>? Vector { get; set; }
+
+        public int Int { get; set; }
+        public string? String { get; set; }
+        public bool Bool { get; set; }
+        public int Int2 { get; set; }
+        public string[] StringArray { get; set; } = null!;
+        public List<string> StringList { get; set; } = null!;
+    }
+#pragma warning restore CA1819 // Properties should not return arrays
+#pragma warning restore CS1819
+
+    public abstract class Fixture : VectorStoreCollectionFixture<TKey, FilterRecord>
+    {
+        public override string CollectionName => "FilterTests";
+
+        public virtual string SpecialCharactersText => """>with $om[ specia]"chara<ters'and\stuff""";
+
+        protected virtual ReadOnlyMemory<float> GetVector(int count)
+            // All records have the same vector - this fixture is about testing criteria filtering only
+            // Derived types may override this to provide different vectors for different records.
+            => new(Enumerable.Range(1, count).Select(i => (float)i).ToArray());
+
+        public virtual VectorStoreCollection<object, Dictionary<string, object?>> DynamicCollection { get; protected set; } = null!;
+
+        public virtual bool TestDynamic => true;
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
+
+            if (this.TestDynamic)
+            {
+                this.DynamicCollection = this.TestStore.DefaultVectorStore.GetDynamicCollection(this.CollectionName, this.CreateRecordDefinition());
+            }
+        }
+
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
+            => new()
+            {
+                Properties =
+                [
+                    new VectorStoreKeyProperty(nameof(FilterRecord.Key), typeof(TKey)),
+                    new VectorStoreVectorProperty(nameof(FilterRecord.Vector), typeof(ReadOnlyMemory<float>?), 3)
+                    {
+                        DistanceFunction = this.DistanceFunction,
+                        IndexKind = this.IndexKind
+                    },
+
+                    new VectorStoreDataProperty(nameof(FilterRecord.Int), typeof(int)) { IsIndexed = true },
+                    new VectorStoreDataProperty(nameof(FilterRecord.String), typeof(string)) { IsIndexed = true },
+                    new VectorStoreDataProperty(nameof(FilterRecord.Bool), typeof(bool)) { IsIndexed = true },
+                    new VectorStoreDataProperty(nameof(FilterRecord.Int2), typeof(int)) { IsIndexed = true },
+                    new VectorStoreDataProperty(nameof(FilterRecord.StringArray), typeof(string[])) { IsIndexed = true },
+                    new VectorStoreDataProperty(nameof(FilterRecord.StringList), typeof(List<string>)) { IsIndexed = true }
+                ]
+            };
+
+        protected override List<FilterRecord> BuildTestData()
+        {
+            return
+            [
+                new()
+                {
+                    Key = this.GenerateNextKey<TKey>(),
+                    Int = 8,
+                    String = "foo",
+                    Bool = true,
+                    Int2 = 80,
+                    StringArray = ["x", "y"],
+                    StringList = ["x", "y"],
+                    Vector = this.GetVector(3)
+                },
+                new()
+                {
+                    Key = this.GenerateNextKey<TKey>(),
+                    Int = 9,
+                    String = "bar",
+                    Bool = false,
+                    Int2 = 90,
+                    StringArray = ["a", "b"],
+                    StringList = ["a", "b"],
+                    Vector = this.GetVector(3)
+                },
+                new()
+                {
+                    Key = this.GenerateNextKey<TKey>(),
+                    Int = 9,
+                    String = "foo",
+                    Bool = true,
+                    Int2 = 9,
+                    StringArray = ["x"],
+                    StringList = ["x"],
+                    Vector = this.GetVector(3)
+                },
+                new()
+                {
+                    Key = this.GenerateNextKey<TKey>(),
+                    Int = 10,
+                    String = null,
+                    Bool = false,
+                    Int2 = 100,
+                    StringArray = ["x", "y", "z"],
+                    StringList = ["x", "y", "z"],
+                    Vector = this.GetVector(3)
+                },
+                new()
+                {
+                    Key = this.GenerateNextKey<TKey>(),
+                    Int = 11,
+                    Bool = true,
+                    String = this.SpecialCharactersText,
+                    Int2 = 101,
+                    StringArray = ["y", "z"],
+                    StringList = ["y", "z"],
+                    Vector = this.GetVector(3)
+                }
+            ];
+        }
+
+        public virtual void AssertEqualFilterRecord(FilterRecord x, FilterRecord y)
+        {
+            var definitionProperties = this.CreateRecordDefinition().Properties;
+
+            Assert.Equal(x.Key, y.Key);
+            Assert.Equal(x.Int, y.Int);
+            Assert.Equal(x.String, y.String);
+            Assert.Equal(x.Int2, y.Int2);
+
+            if (definitionProperties.Any(p => p.Name == nameof(FilterRecord.Bool)))
+            {
+                Assert.Equal(x.Bool, y.Bool);
+            }
+
+            if (definitionProperties.Any(p => p.Name == nameof(FilterRecord.StringArray)))
+            {
+                Assert.Equivalent(x.StringArray, y.StringArray);
+            }
+
+            if (definitionProperties.Any(p => p.Name == nameof(FilterRecord.StringList)))
+            {
+                Assert.Equivalent(x.StringList, y.StringList);
+            }
+        }
+
+        public virtual void AssertEqualDynamic(FilterRecord x, Dictionary<string, object?> y)
+        {
+            var definitionProperties = this.CreateRecordDefinition().Properties;
+
+            Assert.Equal(x.Key, y["Key"]);
+            Assert.Equal(x.Int, y["Int"]);
+            Assert.Equal(x.String, y["String"]);
+            Assert.Equal(x.Int2, y["Int2"]);
+
+            if (definitionProperties.Any(p => p.Name == nameof(FilterRecord.Bool)))
+            {
+                Assert.Equal(x.Bool, y["Bool"]);
+            }
+
+            if (definitionProperties.Any(p => p.Name == nameof(FilterRecord.StringArray)))
+            {
+                Assert.Equivalent(x.StringArray, y["StringArray"]);
+            }
+
+            if (definitionProperties.Any(p => p.Name == nameof(FilterRecord.StringList)))
+            {
+                Assert.Equivalent(x.StringList, y["StringList"]);
+            }
+        }
+
+        // In some databases (Azure AI Search), the data shows up but the filtering index isn't yet updated,
+        // so filtered searches show empty results. Add a filter to the seed data check below.
+        protected override Task WaitForDataAsync()
+            => this.TestStore.WaitForDataAsync(this.Collection, recordCount: this.TestData.Count, r => r.Int > 0);
+    }
+}

--- a/test/VectorData.ConformanceTests/Filter/BasicQueryTests.cs
+++ b/test/VectorData.ConformanceTests/Filter/BasicQueryTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Linq.Expressions;
+
+namespace VectorData.ConformanceTests.Filter;
+
+public abstract class BasicQueryTests<TKey>(BasicQueryTests<TKey>.QueryFixture fixture)
+    : BasicFilterTests<TKey>(fixture) where TKey : notnull
+{
+    protected override async Task<List<FilterRecord>> GetRecords(Expression<Func<FilterRecord, bool>> filter, int top, ReadOnlyMemory<float> vector)
+        => (await fixture.Collection.GetAsync(filter, top).ToListAsync()).OrderBy(r => r.Key).ToList();
+
+    protected override async Task<List<Dictionary<string, object?>>> GetDynamicRecords(Expression<Func<Dictionary<string, object?>, bool>> dynamicFilter, int top, ReadOnlyMemory<float> vector)
+        => (await fixture.DynamicCollection.GetAsync(dynamicFilter, top).ToListAsync()).OrderBy(r => r[nameof(FilterRecord.Key)]!).ToList();
+
+    [Obsolete("Not used by derived types")]
+    public sealed override Task Legacy_And() => Task.CompletedTask;
+
+    [Obsolete("Not used by derived types")]
+    public sealed override Task Legacy_equality() => Task.CompletedTask;
+
+    [Obsolete("Not used by derived types")]
+    public sealed override Task Legacy_AnyTagEqualTo_array() => Task.CompletedTask;
+
+    [Obsolete("Not used by derived types")]
+    public sealed override Task Legacy_AnyTagEqualTo_List() => Task.CompletedTask;
+
+    public abstract class QueryFixture : BasicFilterTests<TKey>.Fixture
+    {
+        private static readonly Random s_random = new();
+
+        public override string CollectionName => "QueryTests";
+
+        /// <summary>
+        /// Use random vectors to make sure that the values don't matter for GetAsync.
+        /// </summary>
+        protected override ReadOnlyMemory<float> GetVector(int count)
+#pragma warning disable CA5394 // Do not use insecure randomness
+            => new(Enumerable.Range(0, count).Select(_ => (float)s_random.NextDouble()).ToArray());
+#pragma warning restore CA5394 // Do not use insecure randomness
+    }
+}

--- a/test/VectorData.ConformanceTests/HybridSearch/KeywordVectorizedHybridSearchComplianceTests.cs
+++ b/test/VectorData.ConformanceTests/HybridSearch/KeywordVectorizedHybridSearchComplianceTests.cs
@@ -1,0 +1,270 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+using VectorData.ConformanceTests.Support;
+using VectorData.ConformanceTests.Xunit;
+using Xunit;
+
+namespace VectorData.ConformanceTests.HybridSearch;
+
+/// <summary>
+/// Base class for common integration tests that should pass for any <see cref="IKeywordHybridSearchable{TRecord}"/>.
+/// </summary>
+/// <typeparam name="TKey">The type of key to use with the record collection.</typeparam>
+public abstract class KeywordVectorizedHybridSearchComplianceTests<TKey>(
+    KeywordVectorizedHybridSearchComplianceTests<TKey>.VectorAndStringFixture vectorAndStringFixture,
+    KeywordVectorizedHybridSearchComplianceTests<TKey>.MultiTextFixture multiTextFixture)
+    where TKey : notnull
+{
+    protected virtual int DelayAfterIndexCreateInMilliseconds { get; } = 0;
+
+    [ConditionalFact]
+    public async Task SearchShouldReturnExpectedResultsAsync()
+    {
+        // Arrange
+        var hybridSearch = vectorAndStringFixture.Collection as IKeywordHybridSearchable<VectorAndStringRecord<TKey>>;
+
+        var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+
+        // Act
+        // All records have the same vector, but the third contains Grapes, so searching for
+        // Grapes should return the third record first.
+        var results = await hybridSearch!.HybridSearchAsync(vector, ["Grapes"], top: 3).ToListAsync();
+        // Assert
+        Assert.Equal(3, results.Count);
+
+        Assert.Equal(3, results[0].Record.Code);
+    }
+
+    [ConditionalFact]
+    public async Task SearchWithFilterShouldReturnExpectedResultsAsync()
+    {
+        // Arrange
+        var hybridSearch = vectorAndStringFixture.Collection as IKeywordHybridSearchable<VectorAndStringRecord<TKey>>;
+
+        var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+
+        // Act
+        // All records have the same vector, but the second contains Oranges, however
+        // adding the filter should limit the results to only the first.
+#pragma warning disable CS0618 // Type or member is obsolete
+        var options = new HybridSearchOptions<VectorAndStringRecord<TKey>>
+        {
+            OldFilter = new VectorSearchFilter().EqualTo("Code", 1)
+        };
+#pragma warning restore CS0618 // Type or member is obsolete
+        var results = await hybridSearch!.HybridSearchAsync(vector, ["Oranges"], top: 3, options).ToListAsync();
+
+        // Assert
+        Assert.Single(results);
+
+        Assert.Equal(1, results[0].Record.Code);
+    }
+
+    [ConditionalFact]
+    public async Task SearchWithTopShouldReturnExpectedResultsAsync()
+    {
+        // Arrange
+        var hybridSearch = vectorAndStringFixture.Collection as IKeywordHybridSearchable<VectorAndStringRecord<TKey>>;
+
+        var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+
+        // Act
+        // All records have the same vector, but the second contains Oranges, so the
+        // second should be returned first.
+        var results = await hybridSearch!.HybridSearchAsync(vector, ["Oranges"], top: 1).ToListAsync();
+
+        // Assert
+        Assert.Single(results);
+
+        Assert.Equal(2, results[0].Record.Code);
+    }
+
+    [ConditionalFact]
+    public async Task SearchWithSkipShouldReturnExpectedResultsAsync()
+    {
+        // Arrange
+        var hybridSearch = vectorAndStringFixture.Collection as IKeywordHybridSearchable<VectorAndStringRecord<TKey>>;
+
+        var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+
+        // Act
+        // All records have the same vector, but the first and third contain healthy,
+        // so when skipping the first two results, we should get the second record.
+        var results = await hybridSearch!.HybridSearchAsync(vector, ["healthy"], top: 3, new() { Skip = 2 }).ToListAsync();
+
+        // Assert
+        Assert.Single(results);
+
+        Assert.Equal(2, results[0].Record.Code);
+    }
+
+    [ConditionalFact]
+    public async Task SearchWithMultipleKeywordsShouldRankMatchedKeywordsHigherAsync()
+    {
+        // Arrange
+        var hybridSearch = vectorAndStringFixture.Collection as IKeywordHybridSearchable<VectorAndStringRecord<TKey>>;
+
+        var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+
+        // Act
+        var results = await hybridSearch!.HybridSearchAsync(vector, ["tangy", "nourishing"], top: 3).ToListAsync();
+
+        // Assert
+        Assert.Equal(3, results.Count);
+
+        Assert.True(results[0].Record.Code.Equals(1) || results[0].Record.Code.Equals(2));
+        Assert.True(results[1].Record.Code.Equals(1) || results[1].Record.Code.Equals(2));
+        Assert.Equal(3, results[2].Record.Code);
+    }
+
+    [ConditionalFact]
+    public async Task SearchWithMultiTextRecordSearchesRequestedFieldAsync()
+    {
+        // Arrange
+        var hybridSearch = multiTextFixture.Collection as IKeywordHybridSearchable<MultiTextStringRecord<TKey>>;
+
+        var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+
+        // Act
+        var results1 = await hybridSearch!.HybridSearchAsync(vector, ["Apples"], top: 3, new() { AdditionalProperty = r => r.Text2 }).ToListAsync();
+        var results2 = await hybridSearch!.HybridSearchAsync(vector, ["Oranges"], top: 3, new() { AdditionalProperty = r => r.Text2 }).ToListAsync();
+
+        // Assert
+        Assert.Equal(2, results1.Count);
+
+        Assert.Equal(2, results1[0].Record.Code);
+        Assert.Equal(1, results1[1].Record.Code);
+
+        Assert.Equal(2, results2.Count);
+
+        Assert.Equal(1, results2[0].Record.Code);
+        Assert.Equal(2, results2[1].Record.Code);
+    }
+
+    public sealed class VectorAndStringRecord<TRecordKey>
+    {
+        public TRecordKey Key { get; set; } = default!;
+
+        public string Text { get; set; } = string.Empty;
+
+        public int Code { get; set; }
+
+        public ReadOnlyMemory<float> Vector { get; set; }
+    }
+
+    public sealed class MultiTextStringRecord<TRecordKey>
+    {
+        public TRecordKey Key { get; set; } = default!;
+
+        public string Text1 { get; set; } = string.Empty;
+
+        public string Text2 { get; set; } = string.Empty;
+
+        public int Code { get; set; }
+
+        public ReadOnlyMemory<float> Vector { get; set; }
+    }
+
+    public abstract class VectorAndStringFixture : VectorStoreCollectionFixture<TKey, VectorAndStringRecord<TKey>>
+    {
+        public override string CollectionName => "KeywordHybridSearch" + this.GetUniqueCollectionName();
+
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
+            => new()
+            {
+                Properties = new List<VectorStoreProperty>()
+                {
+                    new VectorStoreKeyProperty("Key", typeof(TKey)),
+                    new VectorStoreDataProperty("Text", typeof(string)) { IsFullTextIndexed = true },
+                    new VectorStoreDataProperty("Code", typeof(int)) { IsIndexed = true },
+                    new VectorStoreVectorProperty("Vector", typeof(ReadOnlyMemory<float>), 4) { IndexKind = this.IndexKind },
+                }
+            };
+
+        protected override List<VectorAndStringRecord<TKey>> BuildTestData()
+        {
+            // All records have the same vector - this fixture is about testing the full text search portion of hybrid search
+            var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+
+            return
+            [
+                new()
+                {
+                    Key = this.GenerateNextKey<TKey>(),
+                    Text = "Apples are a healthy and nourishing snack",
+                    Vector = vector,
+                    Code = 1
+                },
+                new()
+                {
+                    Key = this.GenerateNextKey<TKey>(),
+                    Text = "Oranges are tangy and contain vitamin c",
+                    Vector = vector,
+                    Code = 2
+                },
+                new()
+                {
+                    Key = this.GenerateNextKey<TKey>(),
+                    Text = "Grapes are healthy, sweet and juicy",
+                    Vector = vector,
+                    Code = 3
+                }
+            ];
+        }
+
+        // In some databases (Azure AI Search), the data shows up but the filtering index isn't yet updated,
+        // so filtered searches show empty results. Add a filter to the seed data check below.
+        protected override Task WaitForDataAsync()
+            => this.TestStore.WaitForDataAsync(this.Collection, recordCount: this.TestData.Count, vectorSize: 4);
+    }
+
+    public abstract class MultiTextFixture : VectorStoreCollectionFixture<TKey, MultiTextStringRecord<TKey>>
+    {
+        public override string CollectionName => "KeywordHybridSearch" + this.GetUniqueCollectionName();
+
+        public override VectorStoreCollectionDefinition CreateRecordDefinition()
+            => new()
+            {
+                Properties = new List<VectorStoreProperty>()
+                {
+                    new VectorStoreKeyProperty("Key", typeof(TKey)),
+                    new VectorStoreDataProperty("Text1", typeof(string)) { IsFullTextIndexed = true },
+                    new VectorStoreDataProperty("Text2", typeof(string)) { IsFullTextIndexed = true },
+                    new VectorStoreDataProperty("Code", typeof(int)) { IsIndexed = true },
+                    new VectorStoreVectorProperty("Vector", typeof(ReadOnlyMemory<float>), 4) { IndexKind = this.IndexKind },
+                }
+            };
+
+        protected override List<MultiTextStringRecord<TKey>> BuildTestData()
+        {
+            // All records have the same vector - this fixture is about testing the full text search portion of hybrid search
+            var vector = new ReadOnlyMemory<float>([1, 0, 0, 0]);
+
+            return
+            [
+                new()
+                {
+                    Key = this.GenerateNextKey<TKey>(),
+                    Text1 = "Apples",
+                    Text2 = "Oranges",
+                    Code = 1,
+                    Vector = vector
+                },
+                new()
+                {
+                    Key = this.GenerateNextKey<TKey>(),
+                    Text1 = "Oranges",
+                    Text2 = "Apples",
+                    Code = 2,
+                    Vector = vector
+                }
+            ];
+        }
+
+        // In some databases (Azure AI Search), the data shows up but the filtering index isn't yet updated,
+        // so filtered searches show empty results. Add a filter to the seed data check below.
+        protected override Task WaitForDataAsync()
+            => this.TestStore.WaitForDataAsync(this.Collection, recordCount: this.TestData.Count, vectorSize: 4);
+    }
+}

--- a/test/VectorData.ConformanceTests/Models/SimpleRecord.cs
+++ b/test/VectorData.ConformanceTests/Models/SimpleRecord.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+using Xunit;
+
+namespace VectorData.ConformanceTests.Models;
+
+/// <summary>
+/// This class represents bare minimum that each connector should support:
+/// a key, int, string and an embedding.
+/// </summary>
+/// <typeparam name="TKey">TKey is a generic parameter because different connectors support different key types.</typeparam>
+public sealed class SimpleRecord<TKey>
+{
+    public const int DimensionCount = 3;
+
+    [VectorStoreKey(StorageName = "key")]
+    public TKey Id { get; set; } = default!;
+
+    [VectorStoreData(StorageName = "text")]
+    public string? Text { get; set; }
+
+    [VectorStoreData(StorageName = "number")]
+    public int Number { get; set; }
+
+    [VectorStoreVector(Dimensions: DimensionCount, StorageName = "embedding")]
+    public ReadOnlyMemory<float> Floats { get; set; }
+
+    public void AssertEqual(SimpleRecord<TKey>? other, bool includeVectors, bool compareVectors)
+    {
+        Assert.NotNull(other);
+        Assert.Equal(this.Id, other.Id);
+        Assert.Equal(this.Text, other.Text);
+        Assert.Equal(this.Number, other.Number);
+
+        if (includeVectors)
+        {
+            Assert.Equal(this.Floats.Span.Length, other.Floats.Span.Length);
+
+            if (compareVectors)
+            {
+                Assert.Equal(this.Floats.ToArray(), other.Floats.ToArray());
+            }
+        }
+        else
+        {
+            Assert.Equal(0, other.Floats.Length);
+        }
+    }
+}

--- a/test/VectorData.ConformanceTests/Support/DynamicDataModelFixture.cs
+++ b/test/VectorData.ConformanceTests/Support/DynamicDataModelFixture.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+
+namespace VectorData.ConformanceTests.Support;
+
+public abstract class DynamicDataModelFixture<TKey> : VectorStoreCollectionFixture<object, Dictionary<string, object?>>
+{
+    public const string KeyPropertyName = "key";
+    public const string StringPropertyName = "text";
+    public const string IntegerPropertyName = "integer";
+    public const string EmbeddingPropertyName = "embedding";
+    public const int DimensionCount = 3;
+
+    protected override VectorStoreCollection<object, Dictionary<string, object?>> GetCollection()
+        => this.TestStore.DefaultVectorStore.GetDynamicCollection(this.CollectionName, this.CreateRecordDefinition());
+
+    public override VectorStoreCollectionDefinition CreateRecordDefinition()
+        => new()
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(KeyPropertyName, typeof(TKey)),
+                new VectorStoreDataProperty(StringPropertyName, typeof(string)),
+                new VectorStoreDataProperty(IntegerPropertyName, typeof(int)),
+                new VectorStoreVectorProperty(EmbeddingPropertyName, typeof(ReadOnlyMemory<float>), DimensionCount)
+            ]
+        };
+
+    protected override List<Dictionary<string, object?>> BuildTestData() =>
+    [
+        new()
+        {
+            [KeyPropertyName] = this.GenerateNextKey<TKey>(),
+            [StringPropertyName] = "first",
+            [IntegerPropertyName] = 1,
+            [EmbeddingPropertyName] = new ReadOnlyMemory<float>(Enumerable.Repeat(0.1f, DimensionCount).ToArray())
+        },
+        new()
+        {
+            [KeyPropertyName] = this.GenerateNextKey<TKey>(),
+            [StringPropertyName] = "second",
+            [IntegerPropertyName] = 2,
+            [EmbeddingPropertyName] = new ReadOnlyMemory<float>(Enumerable.Repeat(0.2f, DimensionCount).ToArray())
+        },
+        new()
+        {
+            [KeyPropertyName] = this.GenerateNextKey<TKey>(),
+            [StringPropertyName] = "third",
+            [IntegerPropertyName] = 3,
+            [EmbeddingPropertyName] = new ReadOnlyMemory<float>(Enumerable.Repeat(0.3f, DimensionCount).ToArray())
+        },
+        new()
+        {
+            [KeyPropertyName] = this.GenerateNextKey<TKey>(),
+            [StringPropertyName] = "fourth",
+            [IntegerPropertyName] = 4,
+            [EmbeddingPropertyName] = new ReadOnlyMemory<float>(Enumerable.Repeat(0.4f, DimensionCount).ToArray())
+        }
+    ];
+}

--- a/test/VectorData.ConformanceTests/Support/SimpleModelFixture.cs
+++ b/test/VectorData.ConformanceTests/Support/SimpleModelFixture.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+using VectorData.ConformanceTests.Models;
+
+namespace VectorData.ConformanceTests.Support;
+
+public abstract class SimpleModelFixture<TKey> : VectorStoreCollectionFixture<TKey, SimpleRecord<TKey>>
+    where TKey : notnull
+{
+    protected override List<SimpleRecord<TKey>> BuildTestData() =>
+    [
+        new()
+        {
+            Id = this.GenerateNextKey<TKey>(),
+            Number = 1,
+            Text = "UsedByGetTests",
+            Floats = Enumerable.Repeat(0.1f, SimpleRecord<TKey>.DimensionCount).ToArray()
+        },
+        new()
+        {
+            Id = this.GenerateNextKey<TKey>(),
+            Number = 2,
+            Text = "UsedByUpdateTests",
+            Floats = Enumerable.Repeat(0.2f, SimpleRecord<TKey>.DimensionCount).ToArray()
+        },
+        new()
+        {
+            Id = this.GenerateNextKey<TKey>(),
+            Number = 3,
+            Text = "UsedByDeleteTests",
+            Floats = Enumerable.Repeat(0.3f, SimpleRecord<TKey>.DimensionCount).ToArray()
+        },
+        new()
+        {
+            Id = this.GenerateNextKey<TKey>(),
+            Number = 4,
+            Text = "UsedByDeleteBatchTests",
+            Floats = Enumerable.Repeat(0.4f, SimpleRecord<TKey>.DimensionCount).ToArray()
+        }
+    ];
+
+    public override VectorStoreCollectionDefinition CreateRecordDefinition()
+        => new()
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(nameof(SimpleRecord<TKey>.Id), typeof(TKey)),
+                new VectorStoreVectorProperty(nameof(SimpleRecord<TKey>.Floats), typeof(ReadOnlyMemory<float>), SimpleRecord<TKey>.DimensionCount)
+                {
+                    DistanceFunction = this.DistanceFunction,
+                    IndexKind = this.IndexKind
+                },
+
+                new VectorStoreDataProperty(nameof(SimpleRecord<TKey>.Number), typeof(int)) { IsIndexed = true },
+                new VectorStoreDataProperty(nameof(SimpleRecord<TKey>.Text), typeof(string)) { IsIndexed = true },
+            ]
+        };
+}

--- a/test/VectorData.ConformanceTests/Support/TestStore.cs
+++ b/test/VectorData.ConformanceTests/Support/TestStore.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Globalization;
+using System.Linq.Expressions;
+using Microsoft.Extensions.VectorData;
+
+namespace VectorData.ConformanceTests.Support;
+
+#pragma warning disable CA1001 // Type owns disposable fields but is not disposable
+
+public abstract class TestStore
+{
+    private readonly SemaphoreSlim _lock = new(1, 1);
+    private int _referenceCount;
+    private VectorStore? _defaultVectorStore;
+
+    /// <summary>
+    /// Some databases modify vectors on upsert, e.g. normalizing them, so vectors
+    /// returned cannot be compared with the original ones.
+    /// </summary>
+    public virtual bool VectorsComparable => true;
+    public virtual string DefaultDistanceFunction => DistanceFunction.CosineSimilarity;
+    public virtual string DefaultIndexKind => IndexKind.Flat;
+
+    protected abstract Task StartAsync();
+
+    protected virtual Task StopAsync()
+        => Task.CompletedTask;
+
+    public VectorStore DefaultVectorStore
+    {
+        get => this._defaultVectorStore ?? throw new InvalidOperationException("Not initialized");
+        set => this._defaultVectorStore = value;
+    }
+
+    public virtual async Task ReferenceCountingStartAsync()
+    {
+        await this._lock.WaitAsync();
+        try
+        {
+            if (this._referenceCount++ == 0)
+            {
+                await this.StartAsync();
+            }
+        }
+        finally
+        {
+            this._lock.Release();
+        }
+    }
+
+    public virtual async Task ReferenceCountingStopAsync()
+    {
+        await this._lock.WaitAsync();
+        try
+        {
+            if (--this._referenceCount == 0)
+            {
+                await this.StopAsync();
+                this._defaultVectorStore?.Dispose();
+            }
+        }
+        finally
+        {
+            this._lock.Release();
+        }
+    }
+
+    public virtual TKey GenerateKey<TKey>(int value)
+        => typeof(TKey) switch
+        {
+            _ when typeof(TKey) == typeof(int) => (TKey)(object)value,
+            _ when typeof(TKey) == typeof(long) => (TKey)(object)(long)value,
+            _ when typeof(TKey) == typeof(ulong) => (TKey)(object)(ulong)value,
+            _ when typeof(TKey) == typeof(string) => (TKey)(object)value.ToString(CultureInfo.InvariantCulture),
+            _ when typeof(TKey) == typeof(Guid) => (TKey)(object)new Guid($"00000000-0000-0000-0000-00{value:0000000000}"),
+
+            _ => throw new NotSupportedException($"Unsupported key of type '{typeof(TKey).Name}', override {nameof(TestStore)}.{nameof(this.GenerateKey)}")
+        };
+
+    /// <summary>Loops until the expected number of records is visible in the given collection.</summary>
+    /// <remarks>Some databases upsert asynchronously, meaning that our seed data may not be visible immediately to tests.</remarks>
+    public virtual async Task WaitForDataAsync<TKey, TRecord>(
+        VectorStoreCollection<TKey, TRecord> collection,
+        int recordCount,
+        Expression<Func<TRecord, bool>>? filter = null,
+        int? vectorSize = null,
+        object? dummyVector = null)
+        where TKey : notnull
+        where TRecord : class
+    {
+        if (vectorSize is not null && dummyVector is not null)
+        {
+            throw new ArgumentException("vectorSize or dummyVector can't both be set");
+        }
+
+        var vector = dummyVector ?? new ReadOnlyMemory<float>(Enumerable.Range(0, vectorSize ?? 3).Select(i => (float)i).ToArray());
+
+        for (var i = 0; i < 20; i++)
+        {
+            var results = collection.SearchAsync(
+                vector,
+                top: recordCount,
+                new() { Filter = filter });
+            var count = await results.CountAsync();
+            if (count == recordCount)
+            {
+                return;
+            }
+            if (count > recordCount)
+            {
+                throw new InvalidOperationException($"Expected at most {recordCount} records, but found {count}.");
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+
+        throw new InvalidOperationException("Data did not appear in the collection within the expected time.");
+    }
+}

--- a/test/VectorData.ConformanceTests/Support/VectorStoreCollectionFixture.cs
+++ b/test/VectorData.ConformanceTests/Support/VectorStoreCollectionFixture.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+
+namespace VectorData.ConformanceTests.Support;
+
+#pragma warning disable CA1721 // Property names should not match get methods
+
+/// <summary>
+/// A test fixture that sets up a single collection in the test vector store, with a specific record definition
+/// and test data.
+/// </summary>
+public abstract class VectorStoreCollectionFixture<TKey, TRecord> : VectorStoreFixture
+    where TKey : notnull
+    where TRecord : class
+{
+    private List<TRecord>? _testData;
+
+    public abstract VectorStoreCollectionDefinition CreateRecordDefinition();
+    protected abstract List<TRecord> BuildTestData();
+
+    public virtual string CollectionName => Guid.NewGuid().ToString();
+    protected virtual string DistanceFunction => this.TestStore.DefaultDistanceFunction;
+    protected virtual string IndexKind => this.TestStore.DefaultIndexKind;
+
+    protected virtual VectorStoreCollection<TKey, TRecord> GetCollection()
+        => this.TestStore.DefaultVectorStore.GetCollection<TKey, TRecord>(this.CollectionName, this.CreateRecordDefinition());
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+
+        this.Collection = this.GetCollection();
+
+        if (await this.Collection.CollectionExistsAsync())
+        {
+            await this.Collection.EnsureCollectionDeletedAsync();
+        }
+
+        await this.Collection.EnsureCollectionExistsAsync();
+        await this.SeedAsync();
+    }
+
+    public virtual VectorStoreCollection<TKey, TRecord> Collection { get; private set; } = null!;
+
+    public List<TRecord> TestData => this._testData ??= this.BuildTestData();
+
+    protected virtual async Task SeedAsync()
+    {
+        await this.Collection.UpsertAsync(this.TestData);
+        await this.WaitForDataAsync();
+    }
+
+    protected virtual Task WaitForDataAsync()
+        => this.TestStore.WaitForDataAsync(this.Collection, recordCount: this.TestData.Count);
+}

--- a/test/VectorData.ConformanceTests/Support/VectorStoreFixture.cs
+++ b/test/VectorData.ConformanceTests/Support/VectorStoreFixture.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+using Xunit;
+
+namespace VectorData.ConformanceTests.Support;
+
+public abstract class VectorStoreFixture : IAsyncLifetime
+{
+    private int _nextKeyValue = 1;
+
+    public abstract TestStore TestStore { get; }
+    public virtual VectorStore VectorStore => this.TestStore.DefaultVectorStore;
+
+    public virtual string DefaultDistanceFunction => this.TestStore.DefaultDistanceFunction;
+    public virtual string DefaultIndexKind => this.TestStore.DefaultIndexKind;
+
+    public virtual string GetUniqueCollectionName() => Guid.NewGuid().ToString();
+
+    public virtual Task InitializeAsync()
+        => this.TestStore.ReferenceCountingStartAsync();
+
+    public virtual Task DisposeAsync()
+        => this.TestStore.ReferenceCountingStopAsync();
+
+    public virtual TKey GenerateNextKey<TKey>()
+        => this.TestStore.GenerateKey<TKey>(Interlocked.Increment(ref this._nextKeyValue));
+}

--- a/test/VectorData.ConformanceTests/VectorData.ConformanceTests.csproj
+++ b/test/VectorData.ConformanceTests/VectorData.ConformanceTests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>VectorData.ConformanceTests</RootNamespace>
+    <NoWarn>$(NoWarn);MEVD9000</NoWarn> <!-- Microsoft.Extensions.VectorData experimental user-facing APIs -->
+    <NoWarn>$(NoWarn);MEVD9001</NoWarn> <!-- Microsoft.Extensions.VectorData experimental provider-facing APIs -->
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <WarningLevel>0</WarningLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="System.Linq.Async" /> <!-- Remove when targeting .NET 10 -->
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.VectorData.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+    <PackageReference Include="System.Memory.Data" />
+  </ItemGroup>
+
+</Project>

--- a/test/VectorData.ConformanceTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
+++ b/test/VectorData.ConformanceTests/VectorSearch/VectorSearchDistanceFunctionComplianceTests.cs
@@ -1,0 +1,184 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+using VectorData.ConformanceTests.Support;
+using VectorData.ConformanceTests.Xunit;
+using Xunit;
+
+namespace VectorData.ConformanceTests.VectorSearch;
+
+public abstract class VectorSearchDistanceFunctionComplianceTests<TKey>(VectorStoreFixture fixture)
+    where TKey : notnull
+{
+    [ConditionalFact]
+    public virtual Task CosineDistance()
+        => this.SimpleSearch(DistanceFunction.CosineDistance, 0, 2, 1, [0, 2, 1]);
+
+    [ConditionalFact]
+    public virtual Task CosineSimilarity()
+        => this.SimpleSearch(DistanceFunction.CosineSimilarity, 1, -1, 0, [0, 2, 1]);
+
+    [ConditionalFact]
+    public virtual Task DotProductSimilarity()
+        => this.SimpleSearch(DistanceFunction.DotProductSimilarity, 1, -1, 0, [0, 2, 1]);
+
+    [ConditionalFact]
+    public virtual Task NegativeDotProductSimilarity()
+        => this.SimpleSearch(DistanceFunction.NegativeDotProductSimilarity, -1, 1, 0, [1, 2, 0]);
+
+    [ConditionalFact]
+    public virtual Task EuclideanDistance()
+        => this.SimpleSearch(DistanceFunction.EuclideanDistance, 0, 2, 1.73, [0, 2, 1]);
+
+    [ConditionalFact]
+    public virtual Task EuclideanSquaredDistance()
+        => this.SimpleSearch(DistanceFunction.EuclideanSquaredDistance, 0, 4, 3, [0, 2, 1]);
+
+    [ConditionalFact]
+    public virtual Task HammingDistance()
+        => this.SimpleSearch(DistanceFunction.HammingDistance, 0, 1, 3, [0, 1, 2]);
+
+    [ConditionalFact]
+    public virtual Task ManhattanDistance()
+        => this.SimpleSearch(DistanceFunction.ManhattanDistance, 0, 2, 3, [0, 1, 2]);
+
+    protected virtual string? IndexKind => null;
+
+    protected async Task SimpleSearch(string distanceFunction, double expectedExactMatchScore,
+        double expectedOppositeScore, double expectedOrthogonalScore, int[] resultOrder)
+    {
+        ReadOnlyMemory<float> baseVector = new([1, 0, 0, 0]);
+        ReadOnlyMemory<float> oppositeVector = new([-1, 0, 0, 0]);
+        ReadOnlyMemory<float> orthogonalVector = new([0f, -1f, -1f, 0f]);
+
+        double[] scoreDictionary = [expectedExactMatchScore, expectedOppositeScore, expectedOrthogonalScore];
+        double[] expectedScores =
+        [
+            scoreDictionary[resultOrder[0]],
+            scoreDictionary[resultOrder[1]],
+            scoreDictionary[resultOrder[2]]
+        ];
+
+        List<SearchRecord> insertedRecords =
+        [
+            new()
+            {
+                Key = fixture.GenerateNextKey<TKey>(),
+                Int = 8,
+                Vector = baseVector,
+            },
+            new()
+            {
+                Key = fixture.GenerateNextKey<TKey>(),
+                Int = 9,
+                String = "bar",
+                Vector = oppositeVector,
+            },
+            new()
+            {
+                Key = fixture.GenerateNextKey<TKey>(),
+                Int = 9,
+                String = "foo",
+                Vector = orthogonalVector,
+            }
+        ];
+        SearchRecord[] expectedRecords =
+        [
+            insertedRecords[resultOrder[0]],
+            insertedRecords[resultOrder[1]],
+            insertedRecords[resultOrder[2]]
+        ];
+
+        // The record definition describes the distance function,
+        // so we need a dedicated collection per test.
+        string uniqueCollectionName = fixture.GetUniqueCollectionName();
+        var collection = fixture.TestStore.DefaultVectorStore.GetCollection<TKey, SearchRecord>(
+            uniqueCollectionName, this.GetRecordDefinition(distanceFunction));
+
+        await collection.EnsureCollectionExistsAsync();
+
+        try
+        {
+            await collection.UpsertAsync(insertedRecords);
+
+            var searchResult = collection.SearchAsync(baseVector, top: 3);
+            var results = await searchResult.ToListAsync();
+            VerifySearchResults(expectedRecords, expectedScores, results, includeVectors: false);
+
+            searchResult = collection.SearchAsync(baseVector, top: 3, new() { IncludeVectors = true });
+            results = await searchResult.ToListAsync();
+            VerifySearchResults(expectedRecords, expectedScores, results, includeVectors: true);
+
+            for (int skip = 0; skip <= insertedRecords.Count; skip++)
+            {
+                for (int top = Math.Max(1, skip); top <= insertedRecords.Count; top++)
+                {
+                    searchResult = collection.SearchAsync(baseVector,
+                        top: top,
+                        new()
+                        {
+                            Skip = skip,
+                            IncludeVectors = true
+                        });
+                    results = await searchResult.ToListAsync();
+
+                    VerifySearchResults(
+                        expectedRecords.Skip(skip).Take(top).ToArray(),
+                        expectedScores.Skip(skip).Take(top).ToArray(),
+                        results, includeVectors: true);
+                }
+            }
+        }
+        finally
+        {
+            await collection.EnsureCollectionDeletedAsync();
+        }
+
+        static void VerifySearchResults(SearchRecord[] expectedRecords, double[] expectedScores,
+            List<VectorSearchResult<SearchRecord>> results, bool includeVectors)
+        {
+            Assert.Equal(expectedRecords.Length, results.Count);
+            for (int i = 0; i < results.Count; i++)
+            {
+                Assert.Equal(expectedRecords[i].Key, results[i].Record.Key);
+                Assert.Equal(expectedRecords[i].Int, results[i].Record.Int);
+                Assert.Equal(expectedRecords[i].String, results[i].Record.String);
+                Assert.Equal(Math.Round(expectedScores[i], 2), Math.Round(results[i].Score!.Value, 2));
+
+                if (includeVectors)
+                {
+                    Assert.Equal(expectedRecords[i].Vector.ToArray(), results[i].Record.Vector.ToArray());
+                }
+                else
+                {
+                    Assert.Equal(0, results[i].Record.Vector.Length);
+                }
+            }
+        }
+    }
+
+    private VectorStoreCollectionDefinition GetRecordDefinition(string distanceFunction)
+        => new()
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(nameof(SearchRecord.Key), typeof(TKey)),
+                new VectorStoreVectorProperty(nameof(SearchRecord.Vector), typeof(ReadOnlyMemory<float>), 4)
+                {
+                    DistanceFunction = distanceFunction,
+                    IndexKind = this.IndexKind
+                },
+                new VectorStoreDataProperty(nameof(SearchRecord.Int), typeof(int)) { IsIndexed = true },
+                new VectorStoreDataProperty(nameof(SearchRecord.String), typeof(string)) { IsIndexed = true },
+            ]
+        };
+
+    public class SearchRecord
+    {
+        public TKey Key { get; set; } = default!;
+        public ReadOnlyMemory<float> Vector { get; set; }
+
+        public int Int { get; set; }
+        public string? String { get; set; }
+    }
+}

--- a/test/VectorData.ConformanceTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
+++ b/test/VectorData.ConformanceTests/VectorSearch/VectorSearchWithFilterConformanceTests.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Microsoft.Extensions.VectorData;
+using VectorData.ConformanceTests.Support;
+using VectorData.ConformanceTests.Xunit;
+using Xunit;
+
+namespace VectorData.ConformanceTests.VectorSearch;
+
+public abstract class VectorSearchWithFilterConformanceTests<TKey>(VectorStoreFixture fixture) where TKey : notnull
+{
+    [ConditionalFact]
+    public async Task SearchWithFilterShouldReturnExpectedResultsAsync()
+    {
+        // Arrange
+        var collectionName = fixture.GetUniqueCollectionName();
+        var collection = fixture.TestStore.DefaultVectorStore.GetCollection<TKey, VectorSearchWithFilterRecord>(collectionName);
+
+        List<VectorSearchWithFilterRecord>? results = null;
+
+        // Act
+        try
+        {
+            await collection.EnsureCollectionExistsAsync();
+
+            List<VectorSearchWithFilterRecord> records =
+            [
+                new VectorSearchWithFilterRecord
+                {
+                    Key = fixture.GenerateNextKey<TKey>(),
+                    Text = "apples",
+                    Vector = new ReadOnlyMemory<float>([1f, 1f, 1f])
+                },
+                new VectorSearchWithFilterRecord
+                {
+                    Key = fixture.GenerateNextKey<TKey>(),
+                    Text = "oranges",
+                    Vector = new ReadOnlyMemory<float>([10f, 20f, 35f])
+                }
+            ];
+
+            await collection.UpsertAsync(records);
+
+            await fixture.TestStore.WaitForDataAsync(collection, records.Count);
+
+            var vectorSearchResults = await collection.SearchAsync(new ReadOnlyMemory<float>([10f, 20f, 35f]), 1, new()
+            {
+                Filter = r => r.Text == "apples"
+            }).ToListAsync();
+
+            results = [.. vectorSearchResults.Select(l => l.Record)];
+        }
+        finally
+        {
+            await collection.EnsureCollectionDeletedAsync();
+        }
+
+        // Assert
+        Assert.Single(results);
+        Assert.Equal("apples", results[0].Text);
+    }
+
+    public class VectorSearchWithFilterRecord
+    {
+        [VectorStoreKey]
+        public TKey Key { get; set; } = default!;
+
+        [VectorStoreData]
+        public string? Text { get; set; }
+
+        [VectorStoreVector(Dimensions: 3)]
+        public ReadOnlyMemory<float> Vector { get; set; }
+    }
+}

--- a/test/VectorData.ConformanceTests/Xunit/ConditionalFactAttribute.cs
+++ b/test/VectorData.ConformanceTests/Xunit/ConditionalFactAttribute.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace VectorData.ConformanceTests.Xunit;
+
+[AttributeUsage(AttributeTargets.Method)]
+[XunitTestCaseDiscoverer("VectorData.ConformanceTests.Xunit.ConditionalFactDiscoverer", "VectorData.ConformanceTests")]
+public sealed class ConditionalFactAttribute : FactAttribute;

--- a/test/VectorData.ConformanceTests/Xunit/ConditionalFactDiscoverer.cs
+++ b/test/VectorData.ConformanceTests/Xunit/ConditionalFactDiscoverer.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace VectorData.ConformanceTests.Xunit;
+
+/// <summary>
+///     Used dynamically from <see cref="ConditionalFactAttribute" />.
+///     Make sure to update that class if you move this type.
+/// </summary>
+public class ConditionalFactDiscoverer(IMessageSink messageSink) : FactDiscoverer(messageSink)
+{
+    protected override IXunitTestCase CreateTestCase(
+        ITestFrameworkDiscoveryOptions discoveryOptions,
+        ITestMethod testMethod,
+        IAttributeInfo factAttribute)
+        => new ConditionalFactTestCase(
+            this.DiagnosticMessageSink,
+            discoveryOptions.MethodDisplayOrDefault(),
+            discoveryOptions.MethodDisplayOptionsOrDefault(),
+            testMethod);
+}

--- a/test/VectorData.ConformanceTests/Xunit/ConditionalFactTestCase.cs
+++ b/test/VectorData.ConformanceTests/Xunit/ConditionalFactTestCase.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace VectorData.ConformanceTests.Xunit;
+
+public sealed class ConditionalFactTestCase : XunitTestCase
+{
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public ConditionalFactTestCase()
+    {
+    }
+
+    public ConditionalFactTestCase(
+        IMessageSink diagnosticMessageSink,
+        TestMethodDisplay defaultMethodDisplay,
+        TestMethodDisplayOptions defaultMethodDisplayOptions,
+        ITestMethod testMethod,
+        object[]? testMethodArguments = null)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
+    {
+    }
+
+    public override async Task<RunSummary> RunAsync(
+        IMessageSink diagnosticMessageSink,
+        IMessageBus messageBus,
+        object[] constructorArguments,
+        ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+        => await XunitTestCaseExtensions.TrySkipAsync(this, messageBus)
+            ? new RunSummary { Total = 1, Skipped = 1 }
+            : await base.RunAsync(
+                diagnosticMessageSink,
+                messageBus,
+                constructorArguments,
+                aggregator,
+                cancellationTokenSource);
+}

--- a/test/VectorData.ConformanceTests/Xunit/ConditionalTheoryAttribute.cs
+++ b/test/VectorData.ConformanceTests/Xunit/ConditionalTheoryAttribute.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace VectorData.ConformanceTests.Xunit;
+
+[AttributeUsage(AttributeTargets.Method)]
+[XunitTestCaseDiscoverer("VectorData.ConformanceTests.Xunit.ConditionalTheoryDiscoverer", "VectorData.ConformanceTests")]
+public sealed class ConditionalTheoryAttribute : TheoryAttribute;

--- a/test/VectorData.ConformanceTests/Xunit/ConditionalTheoryDiscoverer.cs
+++ b/test/VectorData.ConformanceTests/Xunit/ConditionalTheoryDiscoverer.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace VectorData.ConformanceTests.Xunit;
+
+/// <summary>
+///     Used dynamically from <see cref="ConditionalTheoryAttribute" />.
+///     Make sure to update that class if you move this type.
+/// </summary>
+public class ConditionalTheoryDiscoverer(IMessageSink messageSink) : TheoryDiscoverer(messageSink)
+{
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForTheory(
+        ITestFrameworkDiscoveryOptions discoveryOptions,
+        ITestMethod testMethod,
+        IAttributeInfo theoryAttribute)
+    {
+        yield return new ConditionalTheoryTestCase(
+            this.DiagnosticMessageSink,
+            discoveryOptions.MethodDisplayOrDefault(),
+            discoveryOptions.MethodDisplayOptionsOrDefault(),
+            testMethod);
+    }
+
+    protected override IEnumerable<IXunitTestCase> CreateTestCasesForDataRow(
+        ITestFrameworkDiscoveryOptions discoveryOptions,
+        ITestMethod testMethod,
+        IAttributeInfo theoryAttribute,
+        object[] dataRow)
+    {
+        yield return new ConditionalFactTestCase(
+            this.DiagnosticMessageSink,
+            discoveryOptions.MethodDisplayOrDefault(),
+            discoveryOptions.MethodDisplayOptionsOrDefault(),
+            testMethod,
+            dataRow);
+    }
+}

--- a/test/VectorData.ConformanceTests/Xunit/ConditionalTheoryTestCase.cs
+++ b/test/VectorData.ConformanceTests/Xunit/ConditionalTheoryTestCase.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace VectorData.ConformanceTests.Xunit;
+
+public sealed class ConditionalTheoryTestCase : XunitTheoryTestCase
+{
+    [Obsolete("Called by the de-serializer; should only be called by deriving classes for de-serialization purposes")]
+    public ConditionalTheoryTestCase()
+    {
+    }
+
+    public ConditionalTheoryTestCase(
+        IMessageSink diagnosticMessageSink,
+        TestMethodDisplay defaultMethodDisplay,
+        TestMethodDisplayOptions defaultMethodDisplayOptions,
+        ITestMethod testMethod)
+        : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod)
+    {
+    }
+
+    public override async Task<RunSummary> RunAsync(
+        IMessageSink diagnosticMessageSink,
+        IMessageBus messageBus,
+        object[] constructorArguments,
+        ExceptionAggregator aggregator,
+        CancellationTokenSource cancellationTokenSource)
+        => await XunitTestCaseExtensions.TrySkipAsync(this, messageBus)
+            ? new RunSummary { Total = 1, Skipped = 1 }
+            : await base.RunAsync(
+                diagnosticMessageSink,
+                messageBus,
+                constructorArguments,
+                aggregator,
+                cancellationTokenSource);
+}

--- a/test/VectorData.ConformanceTests/Xunit/DisableTestsAttribute.cs
+++ b/test/VectorData.ConformanceTests/Xunit/DisableTestsAttribute.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace VectorData.ConformanceTests.Xunit;
+
+/// <summary>
+/// Disable the tests in the decorated scope.
+/// </summary>
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
+public sealed class DisableTestsAttribute : Attribute, ITestCondition
+{
+    public ValueTask<bool> IsMetAsync()
+    {
+        return new(false);
+    }
+
+    public string Skip { get; set; } = "Test disabled due to usage of DisableTestsAttribute";
+
+    public string SkipReason
+        => this.Skip;
+}

--- a/test/VectorData.ConformanceTests/Xunit/ITestCondition.cs
+++ b/test/VectorData.ConformanceTests/Xunit/ITestCondition.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace VectorData.ConformanceTests.Xunit;
+
+public interface ITestCondition
+{
+    ValueTask<bool> IsMetAsync();
+
+    string SkipReason { get; }
+}

--- a/test/VectorData.ConformanceTests/Xunit/XunitTestCaseExtensions.cs
+++ b/test/VectorData.ConformanceTests/Xunit/XunitTestCaseExtensions.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Collections.Concurrent;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace VectorData.ConformanceTests.Xunit;
+
+public static class XunitTestCaseExtensions
+{
+    private static readonly ConcurrentDictionary<string, List<IAttributeInfo>> s_typeAttributes = new();
+    private static readonly ConcurrentDictionary<string, List<IAttributeInfo>> s_assemblyAttributes = new();
+
+    public static async ValueTask<bool> TrySkipAsync(XunitTestCase testCase, IMessageBus messageBus)
+    {
+        var method = testCase.Method;
+        var type = testCase.TestMethod.TestClass.Class;
+        var assembly = type.Assembly;
+
+        var skipReasons = new List<string>();
+        var attributes =
+            s_assemblyAttributes.GetOrAdd(
+                    assembly.Name,
+                    a => assembly.GetCustomAttributes(typeof(ITestCondition)).ToList())
+                .Concat(
+                    s_typeAttributes.GetOrAdd(
+                        type.Name,
+                        t => type.GetCustomAttributes(typeof(ITestCondition)).ToList()))
+                .Concat(method.GetCustomAttributes(typeof(ITestCondition)))
+                .OfType<ReflectionAttributeInfo>()
+                .Select(attributeInfo => (ITestCondition)attributeInfo.Attribute);
+
+        foreach (var attribute in attributes)
+        {
+            if (!await attribute.IsMetAsync())
+            {
+                skipReasons.Add(attribute.SkipReason);
+            }
+        }
+
+        if (skipReasons.Count > 0)
+        {
+            messageBus.QueueMessage(
+                new TestSkipped(new XunitTest(testCase, testCase.DisplayName), string.Join(Environment.NewLine, skipReasons)));
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/test/VectorData.ConformanceTests/packages.lock.json
+++ b/test/VectorData.ConformanceTests/packages.lock.json
@@ -1,0 +1,363 @@
+{
+  "version": 2,
+  "dependencies": {
+    ".NETFramework,Version=v4.7.2": {
+      "Microsoft.Build.CopyOnWrite": {
+        "type": "Direct",
+        "requested": "[1.0.334, )",
+        "resolved": "1.0.334",
+        "contentHash": "Bi/e5guuwmyPL7Kp1G+PbcDvZFKsZxuHmc39IpYHAhWOvV8I/uIHPwAZ++Fa8k/w6pEqPdHCIrxSCelMNmu0dQ=="
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "Direct",
+        "requested": "[9.6.0, )",
+        "resolved": "9.6.0",
+        "contentHash": "xGO7rHg3qK8jRdriAxIrsH4voNemCf8GVmgdcPXI5gpZ6lZWqOEM4ZO8yfYxUmg7+URw2AY1h7Uc/H17g7X1Kw==",
+        "dependencies": {
+          "System.Text.Json": "8.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "0J/9YNXTMWSZP2p2+nvl8p71zpSwokZXZuJW+VjdErkegAnFdO1XlqtA62SJtgVYHdKu3uPxJHcMR/r35HwFBA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "BmANAnR5Xd4Oqw7yQ75xOAYODybZQRzdeNucg7kS5wWKd2PNnMdYtJ2Vciy0QLylRmv42DGl5+AFL9izA6F1Rw==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.Extensions.VectorData.Abstractions": {
+        "type": "Direct",
+        "requested": "[9.5.0, )",
+        "resolved": "9.5.0",
+        "contentHash": "+hvBYS60Tp9ELEpBVOEa1qBaWgJiEzI9cZdlKf00zJULgI6oPYN/xYps4SaFvyf3O8C+WsDC3Ilsfc147nwVuQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "8.0.0",
+          "Microsoft.Extensions.AI.Abstractions": "9.5.0",
+          "System.Text.Json": "8.0.5",
+          "System.ValueTuple": "4.6.1"
+        }
+      },
+      "System.Linq.Async": {
+        "type": "Direct",
+        "requested": "[6.0.1, )",
+        "resolved": "6.0.1",
+        "contentHash": "0YhHcaroWpQ9UCot3Pizah7ryAzQhNvobLMSxeDIGmnXfkQn8u5owvpOH0K6EVB+z9L7u6Cc4W17Br/+jyttEQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "System.Memory.Data": {
+        "type": "Direct",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "+GDe33iytnNIelPNB0dL/zhQCGDy3Tbhkx11LkHY8EtPKx+TZHEeCA2pDs7RFf7nAbNLSNxpx6ynjhTo0s0U9w==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Text.Json": "9.0.6"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "82rLw487j5jBXEi2r3WvA/cagOhcRREVRtet6izzjDMY+i392W5oNSN2KCtuIvlTpyMONEUD0MIlGAgDdsvQ/w==",
+        "dependencies": {
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3lE/iLSutpgX1CC0NOW70FJoGARRHbyKmG7dc0klnUZ9Dd9hS6N/POPWhKhMLCEuNN5nXEY5agmlFtH562vqhQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g==",
+        "dependencies": {
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Buffers": {
+        "type": "Transitive",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "0nlr0reXrRmkZNKifKqh2DgGhQgfkT7Qa3gQxIn/JI7/y3WDiTz67M+Sq3vFhUqcG8O5zVrpqHvIHeGPGUBsEw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.Numerics.Vectors": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "9.0.6",
+        "contentHash": "uWRgViw2yJAUyGxrzDLCc6fkzE2dZIoXxs8V6YjCujKsJuP0pnpYSlbm2/7tKd0SjBnMtwfDQhLenk3bXonVOA==",
+        "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
+        }
+      },
+      "System.ValueTuple": {
+        "type": "Transitive",
+        "resolved": "4.6.1",
+        "contentHash": "+RJT4qaekpZ7DDLhf+LTjq+E48jieKiY9ulJ+BoxKmZblIJfIJT8Ufcaa/clQqnYvWs8jugfGSMu8ylS0caG0w=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "0Zn6nR/6g+90MxskZyOOMPQvnPnrrGu6bytPwkV+azDcTtCSuQ1+GJUrg8Klmnrjk1i6zMpw2lXijl+tw7Q3kA==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.6",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
+      "System.Text.Json": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "h+ZtYTyTnTh5Ju6mHCKb3FPGx4ylJZgm9W7Y2psUnkhQRPMOIxX+TCN0ZgaR/+Yea+93XHWAaMzYTar1/EHIPg==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.6",
+          "System.Buffers": "4.5.1",
+          "System.IO.Pipelines": "9.0.6",
+          "System.Memory": "4.5.5",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "9.0.6",
+          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
+      "xunit.abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      }
+    },
+    "net8.0": {
+      "Microsoft.Build.CopyOnWrite": {
+        "type": "Direct",
+        "requested": "[1.0.334, )",
+        "resolved": "1.0.334",
+        "contentHash": "Bi/e5guuwmyPL7Kp1G+PbcDvZFKsZxuHmc39IpYHAhWOvV8I/uIHPwAZ++Fa8k/w6pEqPdHCIrxSCelMNmu0dQ=="
+      },
+      "Microsoft.Extensions.AI.Abstractions": {
+        "type": "Direct",
+        "requested": "[9.6.0, )",
+        "resolved": "9.6.0",
+        "contentHash": "xGO7rHg3qK8jRdriAxIrsH4voNemCf8GVmgdcPXI5gpZ6lZWqOEM4ZO8yfYxUmg7+URw2AY1h7Uc/H17g7X1Kw=="
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "0J/9YNXTMWSZP2p2+nvl8p71zpSwokZXZuJW+VjdErkegAnFdO1XlqtA62SJtgVYHdKu3uPxJHcMR/r35HwFBA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "8.0.0",
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "BmANAnR5Xd4Oqw7yQ75xOAYODybZQRzdeNucg7kS5wWKd2PNnMdYtJ2Vciy0QLylRmv42DGl5+AFL9izA6F1Rw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
+        }
+      },
+      "Microsoft.Extensions.VectorData.Abstractions": {
+        "type": "Direct",
+        "requested": "[9.5.0, )",
+        "resolved": "9.5.0",
+        "contentHash": "+hvBYS60Tp9ELEpBVOEa1qBaWgJiEzI9cZdlKf00zJULgI6oPYN/xYps4SaFvyf3O8C+WsDC3Ilsfc147nwVuQ==",
+        "dependencies": {
+          "Microsoft.Extensions.AI.Abstractions": "9.5.0"
+        }
+      },
+      "System.Linq.Async": {
+        "type": "Direct",
+        "requested": "[6.0.1, )",
+        "resolved": "6.0.1",
+        "contentHash": "0YhHcaroWpQ9UCot3Pizah7ryAzQhNvobLMSxeDIGmnXfkQn8u5owvpOH0K6EVB+z9L7u6Cc4W17Br/+jyttEQ==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "3lE/iLSutpgX1CC0NOW70FJoGARRHbyKmG7dc0klnUZ9Dd9hS6N/POPWhKhMLCEuNN5nXEY5agmlFtH562vqhQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "8.0.0"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "0Zn6nR/6g+90MxskZyOOMPQvnPnrrGu6bytPwkV+azDcTtCSuQ1+GJUrg8Klmnrjk1i6zMpw2lXijl+tw7Q3kA=="
+      },
+      "xunit.abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      }
+    }
+  }
+}

--- a/test/VectorData.UnitTests/CollectionModelBuilderTests.cs
+++ b/test/VectorData.UnitTests/CollectionModelBuilderTests.cs
@@ -1,0 +1,437 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.VectorData;
+using Microsoft.Extensions.VectorData.ProviderServices;
+using Xunit;
+
+namespace VectorData.UnitTests;
+
+#pragma warning disable CA2000 // Dispose objects before losing scope
+
+public class CollectionModelBuilderTests
+{
+    [Fact]
+    public void Default_embedding_generator_without_record_definition()
+    {
+        using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<float>>();
+        var model = new CustomModelBuilder().Build(typeof(RecordWithStringVectorProperty), definition: null, embeddingGenerator);
+
+        // The embedding's .NET type (Embedding<float>) is inferred from the embedding generator.
+        Assert.Same(embeddingGenerator, model.VectorProperty.EmbeddingGenerator);
+        Assert.Same(typeof(string), model.VectorProperty.Type);
+        Assert.Same(typeof(Embedding<float>), model.VectorProperty.EmbeddingType);
+    }
+
+    [Fact]
+    public void Default_embedding_generator_with_clr_type_and_record_definition()
+    {
+        using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<Half>>();
+
+        var recordDefinition = new VectorStoreCollectionDefinition
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
+                new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
+                new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(string), dimensions: 3)
+                {
+                    // The following configures the property to be Embedding<Half> (non-default embedding type for this connector)
+                    EmbeddingType = typeof(Embedding<Half>)
+                }
+            ]
+        };
+
+        var model = new CustomModelBuilder().Build(typeof(RecordWithStringVectorProperty), recordDefinition, embeddingGenerator);
+
+        // The embedding's .NET type (Embedding<float>) is inferred from the embedding generator.
+        Assert.Same(embeddingGenerator, model.VectorProperty.EmbeddingGenerator);
+        Assert.Same(typeof(string), model.VectorProperty.Type);
+        Assert.Same(typeof(Embedding<Half>), model.VectorProperty.EmbeddingType);
+    }
+
+    [Fact]
+    public void Default_embedding_generator_with_dynamic()
+    {
+        using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<float>>();
+
+        var recordDefinition = new VectorStoreCollectionDefinition
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
+                new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
+                new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(string), dimensions: 3)
+            ]
+        };
+
+        var model = new CustomModelBuilder().BuildDynamic(recordDefinition, embeddingGenerator);
+
+        // The embedding's .NET type (Embedding<float>) is inferred from the embedding generator.
+        Assert.Same(embeddingGenerator, model.VectorProperty.EmbeddingGenerator);
+        Assert.Same(typeof(string), model.VectorProperty.Type);
+        Assert.Same(typeof(Embedding<float>), model.VectorProperty.EmbeddingType);
+    }
+
+    [Fact]
+    public void Default_embedding_generator_with_dynamic_and_non_default_EmbeddingType()
+    {
+        using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<Half>>();
+
+        var recordDefinition = new VectorStoreCollectionDefinition
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
+                new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
+                new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(string), dimensions: 3)
+                {
+                    EmbeddingType = typeof(Embedding<Half>)
+                }
+            ]
+        };
+
+        var model = new CustomModelBuilder().BuildDynamic(recordDefinition, embeddingGenerator);
+
+        Assert.Same(embeddingGenerator, model.VectorProperty.EmbeddingGenerator);
+        Assert.Same(typeof(string), model.VectorProperty.Type);
+        Assert.Same(typeof(Embedding<Half>), model.VectorProperty.EmbeddingType);
+    }
+
+    [Fact]
+    public void Property_embedding_generator_takes_precedence_over_default_generator()
+    {
+        using var propertyEmbeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<float>>();
+        using var defaultEmbeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<float>>();
+
+        var recordDefinition = new VectorStoreCollectionDefinition
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
+                new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
+                new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(string), dimensions: 3)
+                {
+                    EmbeddingGenerator = propertyEmbeddingGenerator
+                }
+            ]
+        };
+
+        var model = new CustomModelBuilder().BuildDynamic(recordDefinition, defaultEmbeddingGenerator);
+
+        Assert.Same(propertyEmbeddingGenerator, model.VectorProperty.EmbeddingGenerator);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Embedding_property_type_with_default_embedding_generator(bool dynamic)
+    {
+        using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<float>>();
+
+        var model = dynamic
+            ? new CustomModelBuilder().BuildDynamic(
+                new VectorStoreCollectionDefinition
+                {
+                    Properties =
+                    [
+                        new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
+                        new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
+                        new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(ReadOnlyMemory<float>), dimensions: 3)
+                    ]
+                },
+                embeddingGenerator)
+            : new CustomModelBuilder().Build(typeof(RecordWithEmbeddingVectorProperty), definition: null, embeddingGenerator);
+
+        var vectorProperty = model.VectorProperty;
+        Assert.Same(embeddingGenerator, vectorProperty.EmbeddingGenerator);
+        Assert.Same(typeof(ReadOnlyMemory<float>), vectorProperty.Type);
+    }
+
+    [Fact]
+    public void Embedding_property_type_with_property_embedding_generator()
+    {
+        using var embeddingGenerator = new FakeEmbeddingGenerator<int, Embedding<float>>();
+
+        var model = new CustomModelBuilder().Build(
+            typeof(RecordWithEmbeddingVectorProperty),
+            new VectorStoreCollectionDefinition
+            {
+                Properties =
+                [
+                    new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
+                    new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
+                    new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(ReadOnlyMemory<float>), dimensions: 3)
+                    {
+                        EmbeddingGenerator = embeddingGenerator
+                    }
+                ]
+            },
+            embeddingGenerator);
+
+        var vectorProperty = model.VectorProperty;
+        Assert.Same(embeddingGenerator, vectorProperty.EmbeddingGenerator);
+        Assert.Same(typeof(ReadOnlyMemory<float>), vectorProperty.EmbeddingType);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Custom_input_type(bool dynamic)
+    {
+        using var embeddingGenerator = new FakeEmbeddingGenerator<Customer, Embedding<float>>();
+
+        // TODO: Allow custom input type without a record definition (i.e. generic attribute)
+        var recordDefinition = new VectorStoreCollectionDefinition
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
+                new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
+                new VectorStoreVectorProperty<Customer>(nameof(RecordWithEmbeddingVectorProperty.Embedding), dimensions: 3)
+            ]
+        };
+
+        var model = dynamic
+            ? new CustomModelBuilder().BuildDynamic(recordDefinition, embeddingGenerator)
+            : new CustomModelBuilder().Build(typeof(RecordWithCustomerVectorProperty), recordDefinition, embeddingGenerator);
+
+        var vectorProperty = model.VectorProperty;
+
+        Assert.Same(embeddingGenerator, vectorProperty.EmbeddingGenerator);
+        Assert.Same(typeof(Customer), vectorProperty.Type);
+        Assert.Same(typeof(Embedding<float>), vectorProperty.EmbeddingType);
+    }
+
+    [Fact]
+    public void Incompatible_embedding_on_embedding_generator_throws()
+    {
+        // Embedding<long> is not a supported embedding type by the connector
+        using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<long>>();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new CustomModelBuilder().Build(typeof(RecordWithStringVectorProperty), definition: null, embeddingGenerator));
+
+        Assert.Equal($"Embedding generator 'FakeEmbeddingGenerator<string, Embedding<long>>' on vector property '{nameof(RecordWithStringVectorProperty.Embedding)}' cannot convert the input type 'string' to a supported vector type (one of: ReadOnlyMemory<float>, Embedding<float>, float[], ReadOnlyMemory<Half>, Embedding<Half>, Half[]).", exception.Message);
+    }
+
+    [Fact]
+    public void Incompatible_input_on_embedding_generator_throws()
+    {
+        // int is not a supported input type for the embedding generator
+        using var embeddingGenerator = new FakeEmbeddingGenerator<int, Embedding<float>>();
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new CustomModelBuilder().Build(typeof(RecordWithStringVectorProperty), definition: null, embeddingGenerator));
+
+        Assert.Equal($"Embedding generator 'FakeEmbeddingGenerator<int, Embedding<float>>' on vector property '{nameof(RecordWithStringVectorProperty.Embedding)}' cannot convert the input type 'string' to a supported vector type (one of: ReadOnlyMemory<float>, Embedding<float>, float[], ReadOnlyMemory<Half>, Embedding<Half>, Half[]).", exception.Message);
+    }
+
+    [Fact]
+    public void Non_embedding_vector_property_without_embedding_generator_throws()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new CustomModelBuilder().Build(typeof(RecordWithStringVectorProperty), definition: null, defaultEmbeddingGenerator: null));
+
+        Assert.Equal($"Vector property '{nameof(RecordWithStringVectorProperty.Embedding)}' has type 'string' which isn't supported by your provider, and no embedding generator is configured. Configure a generator that supports converting 'string' to vector type supported by your provider.", exception.Message);
+    }
+
+    [Fact]
+    public void EmbeddingType_not_supported_by_provider()
+    {
+        using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<Half>>();
+
+        var recordDefinition = new VectorStoreCollectionDefinition
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
+                new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
+                new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(string), dimensions: 3)
+                {
+                    EmbeddingType = typeof(Embedding<byte>) // The provider supports float/Half only, not byte
+                }
+            ]
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new CustomModelBuilder().Build(typeof(RecordWithStringVectorProperty), recordDefinition, embeddingGenerator));
+
+        Assert.Equal("Vector property 'Embedding' has embedding type 'Embedding<Byte>' configured, but that type isn't supported by your provider. Supported types are ReadOnlyMemory<float>, Embedding<float>, float[], ReadOnlyMemory<Half>, Embedding<Half>, Half[].", exception.Message);
+    }
+
+    [Fact]
+    public void EmbeddingType_not_supported_by_generator()
+    {
+        using var embeddingGenerator = new FakeEmbeddingGenerator<string, Embedding<float>>();
+
+        var recordDefinition = new VectorStoreCollectionDefinition
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
+                new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
+                new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(string), dimensions: 3)
+                {
+                    EmbeddingType = typeof(Embedding<Half>) // The generator (instantiated above) supports only Embedding<float>
+                }
+            ]
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            new CustomModelBuilder().Build(typeof(RecordWithStringVectorProperty), recordDefinition, embeddingGenerator));
+
+        Assert.Equal("Vector property 'Embedding' has embedding type 'Embedding<Half>' configured, but that type isn't supported by your embedding generator.", exception.Message);
+    }
+
+    [Fact]
+    public void Missing_Type_on_property_definition()
+    {
+        var recordDefinition = new VectorStoreCollectionDefinition
+        {
+            Properties =
+            [
+                new VectorStoreKeyProperty(nameof(RecordWithEmbeddingVectorProperty.Id), typeof(int)),
+                new VectorStoreDataProperty(nameof(RecordWithEmbeddingVectorProperty.Name), typeof(string)),
+                new VectorStoreVectorProperty(nameof(RecordWithEmbeddingVectorProperty.Embedding), typeof(ReadOnlyMemory<float>), dimensions: 3)
+            ]
+        };
+
+        // Key
+        recordDefinition.Properties[0].Type = null;
+        var exception = Assert.Throws<InvalidOperationException>(() => new CustomModelBuilder().BuildDynamic(recordDefinition, defaultEmbeddingGenerator: null));
+        Assert.Equal($"Property '{nameof(RecordWithEmbeddingVectorProperty.Id)}' has no type specified in its definition, and does not have a corresponding .NET property. Specify the type on the definition.", exception.Message);
+
+        // Data
+        recordDefinition.Properties[0].Type = typeof(int);
+        recordDefinition.Properties[1].Type = null;
+        exception = Assert.Throws<InvalidOperationException>(() => new CustomModelBuilder().BuildDynamic(recordDefinition, defaultEmbeddingGenerator: null));
+        Assert.Equal($"Property '{nameof(RecordWithEmbeddingVectorProperty.Name)}' has no type specified in its definition, and does not have a corresponding .NET property. Specify the type on the definition.", exception.Message);
+
+        // Vector
+        recordDefinition.Properties[1].Type = typeof(string);
+        recordDefinition.Properties[2].Type = null;
+        exception = Assert.Throws<InvalidOperationException>(() => new CustomModelBuilder().BuildDynamic(recordDefinition, defaultEmbeddingGenerator: null));
+        Assert.Equal($"Property '{nameof(RecordWithEmbeddingVectorProperty.Embedding)}' has no type specified in its definition, and does not have a corresponding .NET property. Specify the type on the definition.", exception.Message);
+    }
+
+    public class RecordWithStringVectorProperty
+    {
+        [VectorStoreKey]
+        public int Id { get; set; }
+
+        [VectorStoreData]
+        public string Name { get; set; }
+
+        [VectorStoreVector(Dimensions: 3)]
+        public string Embedding { get; set; }
+    }
+
+    public class RecordWithEmbeddingVectorProperty
+    {
+        [VectorStoreKey]
+        public int Id { get; set; }
+
+        [VectorStoreData]
+        public string Name { get; set; }
+
+        [VectorStoreVector(Dimensions: 3)]
+        public ReadOnlyMemory<float> Embedding { get; set; }
+    }
+
+    public class RecordWithCustomerVectorProperty
+    {
+        [VectorStoreKey]
+        public int Id { get; set; }
+
+        [VectorStoreData]
+        public string Name { get; set; }
+
+        [VectorStoreVector(Dimensions: 3)]
+        public Customer Embedding { get; set; }
+    }
+
+    public class Customer
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+    }
+
+    private sealed class CustomModelBuilder(CollectionModelBuildingOptions? options = null)
+        : CollectionModelBuilder(options ?? s_defaultOptions)
+    {
+        private static readonly CollectionModelBuildingOptions s_defaultOptions = new()
+        {
+            SupportsMultipleKeys = false,
+            SupportsMultipleVectors = true,
+            RequiresAtLeastOneVector = false
+        };
+
+        protected override bool IsKeyPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
+        {
+            supportedTypes = "string, int";
+
+            return type == typeof(string) || type == typeof(int);
+        }
+
+        protected override bool IsDataPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
+        {
+            supportedTypes = "string, int";
+
+            if (Nullable.GetUnderlyingType(type) is Type underlyingType)
+            {
+                type = underlyingType;
+            }
+
+            return type == typeof(string) || type == typeof(int);
+        }
+
+        protected override bool IsVectorPropertyTypeValid(Type type, [NotNullWhen(false)] out string? supportedTypes)
+            => IsVectorPropertyTypeValidCore(type, out supportedTypes);
+
+        internal static bool IsVectorPropertyTypeValidCore(Type type, [NotNullWhen(false)] out string? supportedTypes)
+        {
+            supportedTypes = "ReadOnlyMemory<float>, Embedding<float>, float[], ReadOnlyMemory<Half>, Embedding<Half>, Half[]";
+
+            if (Nullable.GetUnderlyingType(type) is Type underlyingType)
+            {
+                type = underlyingType;
+            }
+
+            return type == typeof(ReadOnlyMemory<float>)
+                || type == typeof(Embedding<float>)
+                || type == typeof(float[])
+                || type == typeof(ReadOnlyMemory<Half>)
+                || type == typeof(Embedding<Half>)
+                || type == typeof(Half[]);
+        }
+
+        protected override Type? ResolveEmbeddingType(
+            VectorPropertyModel vectorProperty,
+            IEmbeddingGenerator embeddingGenerator,
+            Type? userRequestedEmbeddingType)
+            => vectorProperty.ResolveEmbeddingType<Embedding<float>>(embeddingGenerator, userRequestedEmbeddingType)
+                ?? vectorProperty.ResolveEmbeddingType<Embedding<Half>>(embeddingGenerator, userRequestedEmbeddingType);
+    }
+
+    private sealed class FakeEmbeddingGenerator<TInput, TEmbedding> : IEmbeddingGenerator<TInput, TEmbedding>
+        where TEmbedding : Embedding
+    {
+        public Task<GeneratedEmbeddings<TEmbedding>> GenerateAsync(
+            IEnumerable<TInput> values,
+            EmbeddingGenerationOptions? options = null,
+            CancellationToken cancellationToken = default)
+            => throw new UnreachableException();
+
+        public object? GetService(Type serviceType, object? serviceKey = null)
+            => throw new UnreachableException();
+
+        public void Dispose() { }
+    }
+}

--- a/test/VectorData.UnitTests/VectorData.UnitTests.csproj
+++ b/test/VectorData.UnitTests/VectorData.UnitTests.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <AssemblyName>VectorData.UnitTests</AssemblyName>
+    <RootNamespace>VectorData.UnitTests</RootNamespace>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);VSTHRD111,CA2007,CS8618</NoWarn>
+    <NoWarn>$(NoWarn);MEVD9001</NoWarn> <!-- Experimental MEVD connector-facing APIs -->
+    <NoWarn>$(NoWarn);CA1515</NoWarn> <!-- Because an application's API isn't typically referenced from outside the assembly, types can be made internal -->
+    <NoWarn>$(NoWarn);CA1707</NoWarn> <!-- Remove the underscores from member name -->
+    <NoWarn>$(NoWarn);CA1716</NoWarn> <!-- Rename virtual/interface member so that it no longer conflicts with the reserved language keyword -->
+    <NoWarn>$(NoWarn);CA1720</NoWarn> <!-- Identifier contains type name -->
+    <NoWarn>$(NoWarn);CA1721</NoWarn> <!-- The property name X is confusing given the existence of method Y. Rename or remove one of these members. -->
+    <NoWarn>$(NoWarn);CA1861</NoWarn> <!-- Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array -->
+    <NoWarn>$(NoWarn);CA1863</NoWarn> <!-- Cache a 'CompositeFormat' for repeated use in this formatting operation -->
+    <NoWarn>$(NoWarn);CA2007;VSTHRD111</NoWarn> <!-- Consider calling ConfigureAwait on the awaited task -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn> <!-- Missing XML comment for publicly visible type or member -->
+    <NoWarn>$(NoWarn);IDE1006</NoWarn> <!-- Naming rule violation: Missing suffix: 'Async' -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\VectorData\VectorData.Abstractions\VectorData.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds a copy of the [generic conformance tests](https://github.com/microsoft/semantic-kernel/tree/dotnet-1.56.0/dotnet/test/VectorData/VectorData.ConformanceTests) maintained by Microsoft in the Semantic Kernel repository (until they are stable enough to get published as NuGet package).

Implements all basic conformance tests for the `Elasticsearch` connector.